### PR TITLE
Emit run heartbeats every minute

### DIFF
--- a/bugcam/commands/run.py
+++ b/bugcam/commands/run.py
@@ -29,7 +29,7 @@ from bugcam.runtime import build_pipeline, resolve_bundle_provenance, select_mod
 
 app = typer.Typer(help="Record, process, upload, and emit heartbeats", invoke_without_command=True, no_args_is_help=False)
 console = Console()
-HEARTBEAT_INTERVAL_SECONDS = 3600
+HEARTBEAT_INTERVAL_SECONDS = 60
 ENVIRONMENT_INTERVAL_SECONDS = 60
 PID_FILE_PATH = get_state_dir() / "bugcam.pid"
 
@@ -172,7 +172,7 @@ def run(
         help="Clean up results after uploading",
     ),
 ) -> None:
-    """Run recording, processing, uploading, and hourly heartbeat emission."""
+    """Run recording, processing, uploading, and one-minute heartbeat emission."""
     if mode not in {"continuous", "interval"}:
         raise typer.BadParameter("mode must be 'continuous' or 'interval'")
     try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,13 @@ def test_run_subcommand_help(cli_runner):
     assert "--resolution" in result.output
 
 
+def test_run_heartbeat_interval_is_one_minute() -> None:
+    """Test run command emits heartbeat snapshots every minute."""
+    from bugcam.commands.run import HEARTBEAT_INTERVAL_SECONDS
+
+    assert HEARTBEAT_INTERVAL_SECONDS == 60
+
+
 def test_process_subcommand_help(cli_runner):
     """Test process subcommand is accessible."""
     result = cli_runner.invoke(app, ["process", "--help"])


### PR DESCRIPTION
## Summary

Change `bugcam run` heartbeat emission from hourly to every minute.

## Why

The dashboard expects heartbeat data to reflect current device status. A one-hour cadence makes online/offline state stale for local Pi monitoring.

## Changes

- Set `HEARTBEAT_INTERVAL_SECONDS` to 60 seconds.
- Update the `bugcam run` docstring to describe one-minute heartbeat emission.
- Add a focused regression test for the interval constant.

## Validation

- `python -m py_compile bugcam/commands/run.py tests/test_cli.py`
- Static AST check confirmed `HEARTBEAT_INTERVAL_SECONDS == 60` and `ENVIRONMENT_INTERVAL_SECONDS == 60`.
- Playwright dashboard check against a local mock API confirmed `/heartbeats`, filtered `/heartbeats?device_id=garden-local-1`, and `/environment` render FLICK and DOT rows.

Full pytest collection is blocked on this local host because `hailo_platform` is unavailable. Poetry install is also blocked by the existing `pyproject.toml` / `poetry.lock` mismatch on `main`.
