### PR TITLE
Prompt for BugCam storage paths during setup

### DIFF
--- a/bugcam/commands/environment.py
+++ b/bugcam/commands/environment.py
@@ -18,11 +18,12 @@ console = Console()
 
 @app.callback()
 def environment(
-    output_dir: Path = typer.Option(get_output_storage_dir(), "--output-dir", help="Directory for processed output"),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Directory for processed output"),
     device_id: str | None = typer.Option(None, "--device-id", "--flick-id", help="FLICK device ID"),
 ) -> None:
     """Collect one environmental reading from the SEN55 sensor."""
     flick_id = resolve_flick_id(device_id)
+    output_dir = output_dir or get_output_storage_dir()
     try:
         output_path, payload = collect_environment_reading(output_dir=output_dir, flick_id=flick_id)
     except FileNotFoundError as exc:

--- a/bugcam/commands/heartbeat.py
+++ b/bugcam/commands/heartbeat.py
@@ -101,11 +101,13 @@ def _resolve_runtime_settings(
 def heartbeat(
     flick_id: str | None = typer.Option(None, "--flick-id", help="FLICK device ID"),
     dot_ids: str | None = typer.Option(None, "--dot-ids", help="Comma-separated DOT IDs"),
-    input_dir: Path = typer.Option(get_input_storage_dir(), "--input-dir", help="Directory containing DOT inputs"),
-    output_dir: Path = typer.Option(get_output_storage_dir(), "--output-dir", help="Directory for processed output"),
+    input_dir: Path | None = typer.Option(None, "--input-dir", help="Directory containing DOT inputs"),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Directory for processed output"),
 ) -> None:
     """Write a single heartbeat snapshot."""
     settings = _resolve_runtime_settings(flick_id, dot_ids)
+    input_dir = input_dir or get_input_storage_dir()
+    output_dir = output_dir or get_output_storage_dir()
     heartbeat_path = write_heartbeat_snapshot(
         output_dir=output_dir,
         flick_id=settings["flick_id"],

--- a/bugcam/commands/process.py
+++ b/bugcam/commands/process.py
@@ -16,8 +16,8 @@ console = Console()
 
 @app.callback()
 def process(
-    input_dir: Path = typer.Option(get_input_storage_dir(), "--input-dir", help="Directory containing input videos and DOT folders"),
-    output_dir: Path = typer.Option(get_output_storage_dir(), "--output-dir", help="Directory for processed output"),
+    input_dir: Path | None = typer.Option(None, "--input-dir", help="Directory containing input videos and DOT folders"),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Directory for processed output"),
     model: str = typer.Option(..., "--model", help="Model bundle name or model.hef path"),
     flick_id: str | None = typer.Option(None, "--flick-id", help="FLICK device ID"),
     classification: bool = typer.Option(True, "--classification/--no-classification", help="Enable classification"),
@@ -26,6 +26,8 @@ def process(
     """Process existing files without recording."""
     device_config = load_device_config()
     resolved_flick_id = resolve_flick_id(flick_id)
+    input_dir = input_dir or get_input_storage_dir()
+    output_dir = output_dir or get_output_storage_dir()
     input_dir.mkdir(parents=True, exist_ok=True)
     output_dir.mkdir(parents=True, exist_ok=True)
     provenance = resolve_bundle_provenance(model)

--- a/bugcam/commands/record.py
+++ b/bugcam/commands/record.py
@@ -9,16 +9,12 @@ from pathlib import Path
 from datetime import datetime
 from rich.console import Console
 from typing import Optional
-from ..config import get_input_storage_dir
+from ..config import get_output_storage_dir
 from ..device_config import resolve_flick_id
 from ..processing import parse_capture_resolution
 
 app = typer.Typer(help="Record videos from camera")
 console = Console()
-
-# Default output directory
-DEFAULT_OUTPUT_DIR = get_input_storage_dir()
-
 
 def _build_recording_path(output_dir: Path, flick_id: str) -> Path:
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -161,8 +157,9 @@ def single(
 
     # Generate output path if not specified
     if output is None:
-        DEFAULT_OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-        output = _build_recording_path(DEFAULT_OUTPUT_DIR, resolved_flick_id)
+        output_dir = get_output_storage_dir()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output = _build_recording_path(output_dir, resolved_flick_id)
     else:
         output.parent.mkdir(parents=True, exist_ok=True)
 

--- a/bugcam/commands/run.py
+++ b/bugcam/commands/run.py
@@ -157,8 +157,8 @@ def run(
     api_key: str | None = typer.Option(None, "--api-key", help="Per-device API key"),
     flick_id: str | None = typer.Option(None, "--flick-id", help="FLICK device ID"),
     dot_ids: str | None = typer.Option(None, "--dot-ids", help="Comma-separated DOT IDs"),
-    input_dir: Path = typer.Option(get_input_storage_dir(), "--input-dir", help="Directory for recorded input"),
-    output_dir: Path = typer.Option(get_output_storage_dir(), "--output-dir", help="Directory for processed output"),
+    input_dir: Path | None = typer.Option(None, "--input-dir", help="Directory for recorded input"),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Directory for processed output"),
     model: str | None = typer.Option(None, "--model", help="Model bundle name or model.hef path"),
     mode: str = typer.Option("continuous", "--mode", help="'continuous' (always recording) or 'interval' (record periodically)"),
     interval: int = typer.Option(5, "--interval", help="Minutes between recordings in interval mode"),
@@ -188,6 +188,8 @@ def run(
             console.print(f"[yellow]Warning[/yellow] {ntp_detail}")
 
         settings = _resolve_runtime_settings(api_url, api_key, flick_id, dot_ids, bucket)
+        input_dir = input_dir or get_input_storage_dir()
+        output_dir = output_dir or get_output_storage_dir()
         input_dir.mkdir(parents=True, exist_ok=True)
         output_dir.mkdir(parents=True, exist_ok=True)
         selected_model = select_model_reference(model)

--- a/bugcam/commands/setup.py
+++ b/bugcam/commands/setup.py
@@ -1,6 +1,7 @@
 """Setup command for BugCam."""
 from __future__ import annotations
 
+import os
 import platform
 import shutil
 import subprocess
@@ -15,8 +16,14 @@ from rich.console import Console
 from ..config import (
     DEFAULT_API_URL,
     DEFAULT_S3_BUCKET,
+    INPUT_DIR_CONFIG_KEY,
+    OUTPUT_DIR_CONFIG_KEY,
     get_default_flick_id,
+    get_default_input_storage_dir,
+    get_default_output_storage_dir,
     get_hailo_venv_dir,
+    get_input_storage_dir,
+    get_output_storage_dir,
     get_python_for_detection,
     get_state_dir,
     load_config,
@@ -125,11 +132,40 @@ def _existing_dot_count(existing_config: dict[str, Any]) -> int:
     return 0
 
 
+def _validate_storage_dir(path: Path, default_path: Path, label: str) -> Path:
+    selected_path = path.expanduser().resolve(strict=False)
+    if selected_path == default_path.expanduser().resolve(strict=False):
+        selected_path.mkdir(parents=True, exist_ok=True)
+    if not selected_path.exists():
+        raise ValueError(f"{label} folder does not exist: {selected_path}")
+    if not selected_path.is_dir():
+        raise ValueError(f"{label} folder is not a directory: {selected_path}")
+    if not os.access(selected_path, os.R_OK | os.W_OK | os.X_OK):
+        raise ValueError(f"{label} folder is not accessible: {selected_path}")
+    probe_path = selected_path / ".bugcam-setup-write-test"
+    try:
+        probe_path.write_text("", encoding="utf-8")
+        probe_path.unlink()
+    except OSError as exc:
+        raise ValueError(f"{label} folder is not writable: {selected_path}") from exc
+    return selected_path
+
+
 def _prompt_registration_settings(existing_config: dict[str, Any]) -> dict[str, Any]:
     return {
         "api_url": typer.prompt("API URL", default=str(existing_config.get("api_url") or DEFAULT_API_URL)),
         "flick_id": typer.prompt("Device ID (unique name for this device)", default=_existing_flick_id(existing_config)),
         "dot_count": typer.prompt("Number of DOT sensors (0 if none)", default=_existing_dot_count(existing_config), type=int),
+        "input_dir": _validate_storage_dir(
+            Path(typer.prompt("Input folder", default=str(get_input_storage_dir().expanduser().resolve(strict=False)))),
+            get_default_input_storage_dir(),
+            "Input",
+        ),
+        "output_dir": _validate_storage_dir(
+            Path(typer.prompt("Output folder", default=str(get_output_storage_dir().expanduser().resolve(strict=False)))),
+            get_default_output_storage_dir(),
+            "Output",
+        ),
     }
 
 
@@ -188,11 +224,24 @@ def _build_saved_config(
     api_key: str,
     flick_id: str,
     dot_ids: list[str],
+    input_dir: Path,
+    output_dir: Path,
 ) -> dict[str, Any]:
     preserved = {
         key: value
         for key, value in existing_config.items()
-        if key not in {"api_url", "api_key", "device_id", "device_name", "flick_id", "dot_ids", "s3_bucket"}
+        if key
+        not in {
+            "api_url",
+            "api_key",
+            "device_id",
+            "device_name",
+            "flick_id",
+            "dot_ids",
+            INPUT_DIR_CONFIG_KEY,
+            OUTPUT_DIR_CONFIG_KEY,
+            "s3_bucket",
+        }
     }
     return {
         **preserved,
@@ -200,6 +249,8 @@ def _build_saved_config(
         "api_key": api_key,
         "flick_id": flick_id,
         "dot_ids": dot_ids,
+        INPUT_DIR_CONFIG_KEY: str(input_dir),
+        OUTPUT_DIR_CONFIG_KEY: str(output_dir),
         "s3_bucket": str(existing_config.get("s3_bucket") or DEFAULT_S3_BUCKET),
     }
 
@@ -276,6 +327,8 @@ def setup() -> None:
             api_key=api_key,
             flick_id=flick_id,
             dot_ids=dot_ids,
+            input_dir=settings["input_dir"],
+            output_dir=settings["output_dir"],
         )
         save_config(saved_config)
         console.print(f"[green]Saved config for {saved_config['flick_id']}[/green]\n")

--- a/bugcam/commands/upload.py
+++ b/bugcam/commands/upload.py
@@ -360,7 +360,7 @@ def _resolve_runtime_settings(
 
 @app.callback()
 def upload(
-    output_dir: Path = typer.Option(get_output_storage_dir(), "--output-dir", help="Processed output directory to watch"),
+    output_dir: Path | None = typer.Option(None, "--output-dir", help="Processed output directory to watch"),
     api_url: str | None = typer.Option(None, "--api-url", help="Backend API URL"),
     api_key: str | None = typer.Option(None, "--api-key", help="Per-device API key"),
     bucket: str | None = typer.Option(None, "--bucket", help="Configured output bucket"),
@@ -374,6 +374,7 @@ def upload(
     dot_ids: str | None = typer.Option(None, "--dot-ids", help="Comma-separated DOT IDs"),
 ) -> None:
     """Watch an output directory and upload ready result directories."""
+    output_dir = output_dir or get_output_storage_dir()
     output_dir.mkdir(parents=True, exist_ok=True)
     settings = _resolve_runtime_settings(api_url, api_key, flick_id, dot_ids, bucket)
     stop_event = threading.Event()

--- a/bugcam/config.py
+++ b/bugcam/config.py
@@ -9,6 +9,8 @@ from typing import Any
 
 DEFAULT_API_URL = "https://api.sensinggarden.com/v1"
 DEFAULT_S3_BUCKET = "scl-sensing-garden"
+INPUT_DIR_CONFIG_KEY = "input_dir"
+OUTPUT_DIR_CONFIG_KEY = "output_dir"
 
 
 def get_config_path() -> Path:
@@ -86,20 +88,34 @@ def get_state_dir() -> Path:
     return Path.home() / ".local" / "share" / "bugcam"
 
 
+def get_default_input_storage_dir() -> Path:
+    """Get the built-in edge26 input storage directory."""
+    return get_state_dir() / "incoming"
+
+
+def get_default_output_storage_dir() -> Path:
+    """Get the built-in edge26 output storage directory."""
+    return get_state_dir() / "outputs"
+
+
+def _get_storage_dir(env_key: str, config_key: str, default_path: Path) -> Path:
+    env_value = os.environ.get(env_key)
+    if env_value:
+        return Path(env_value)
+    config_value = load_config().get(config_key)
+    if config_value:
+        return Path(str(config_value))
+    return default_path
+
+
 def get_input_storage_dir() -> Path:
     """Get the edge26 input storage directory."""
-    input_dir = os.environ.get("BUGCAM_INPUT_DIR")
-    if input_dir:
-        return Path(input_dir)
-    return get_state_dir() / "incoming"
+    return _get_storage_dir("BUGCAM_INPUT_DIR", INPUT_DIR_CONFIG_KEY, get_default_input_storage_dir())
 
 
 def get_output_storage_dir() -> Path:
     """Get the edge26 output storage directory."""
-    output_dir = os.environ.get("BUGCAM_OUTPUT_DIR")
-    if output_dir:
-        return Path(output_dir)
-    return get_state_dir() / "outputs"
+    return _get_storage_dir("BUGCAM_OUTPUT_DIR", OUTPUT_DIR_CONFIG_KEY, get_default_output_storage_dir())
 
 
 def get_default_flick_id() -> str:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -72,12 +72,6 @@ def test_remux_video_no_ffmpeg(tmp_path: Path) -> None:
         assert result is True  # Returns True (no error, just skipped)
 
 
-def test_default_output_dir() -> None:
-    """Test default output directory is set correctly."""
-    from bugcam.commands.record import DEFAULT_OUTPUT_DIR
-    assert DEFAULT_OUTPUT_DIR == Path.home() / ".local" / "share" / "bugcam" / "incoming"
-
-
 def test_check_disk_space_sufficient(tmp_path: Path) -> None:
     """Test _check_disk_space returns True when sufficient space."""
     from bugcam.commands.record import _check_disk_space
@@ -123,19 +117,16 @@ def test_record_single_uses_resolved_flick_id_for_generated_filename(tmp_path: P
     from bugcam.commands import record
 
     captured = {}
-    original_output_dir = record.DEFAULT_OUTPUT_DIR
-    record.DEFAULT_OUTPUT_DIR = tmp_path
 
-    try:
-        with patch('bugcam.commands.record.platform.system', return_value='Linux'), \
-             patch('bugcam.commands.record._check_camera_available', return_value=True), \
-             patch('bugcam.commands.record._check_disk_space', return_value=(True, 1000)), \
-             patch('bugcam.commands.record.resolve_flick_id', return_value='flick-config'), \
-             patch('bugcam.commands.record._remux_video', return_value=True), \
-             patch('bugcam.commands.record._record_single_video') as mock_record:
-            mock_record.side_effect = lambda output, length, quiet, resolution: captured.setdefault("name", output.name) or True
-            record.single(output=None, length=1, flick_id=None, resolution="1080x1080")
-    finally:
-        record.DEFAULT_OUTPUT_DIR = original_output_dir
+    with patch('bugcam.commands.record.platform.system', return_value='Linux'), \
+         patch('bugcam.commands.record._check_camera_available', return_value=True), \
+         patch('bugcam.commands.record._check_disk_space', return_value=(True, 1000)), \
+         patch('bugcam.commands.record.get_output_storage_dir', return_value=tmp_path), \
+         patch('bugcam.commands.record.resolve_flick_id', return_value='flick-config'), \
+         patch('bugcam.commands.record._remux_video', return_value=True), \
+         patch('bugcam.commands.record._record_single_video') as mock_record:
+        mock_record.side_effect = lambda output, length, quiet, resolution: captured.setdefault("path", output) or True
+        record.single(output=None, length=1, flick_id=None, resolution="1080x1080")
 
-    assert captured["name"].startswith("flick-config_")
+    assert captured["path"].parent == tmp_path
+    assert captured["path"].name.startswith("flick-config_")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -267,8 +267,119 @@ def test_setup_verifies_hailo_apps(cli_runner: CliRunner, tmp_path: Path) -> Non
          patch('bugcam.commands.setup.check_import', return_value=True) as mock_check, \
          patch('bugcam.commands.setup.load_config', return_value=existing_config), \
          patch('bugcam.commands.setup.save_config'), \
+         patch('bugcam.commands.setup._validate_storage_dir', side_effect=lambda path, *_: path), \
          patch('bugcam.commands.setup._install_sen55_binary'):
-        result = cli_runner.invoke(app, ["setup"], input="\n\n\nn\n")
+        result = cli_runner.invoke(app, ["setup"], input="\n\n\n\n\nn\n")
         assert "hailo_apps: OK" in result.output
 
         mock_check.assert_called_with(mock_check.call_args[0][0], "hailo_apps")
+
+
+def test_config_uses_saved_storage_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test storage directories are read from persistent config."""
+    from bugcam.config import get_input_storage_dir, get_output_storage_dir
+
+    config_dir = tmp_path / ".config" / "bugcam"
+    config_dir.mkdir(parents=True)
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    (config_dir / "config.json").write_text(
+        f'{{"input_dir": "{input_dir}", "output_dir": "{output_dir}"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.delenv("BUGCAM_INPUT_DIR", raising=False)
+    monkeypatch.delenv("BUGCAM_OUTPUT_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    assert get_input_storage_dir() == input_dir
+    assert get_output_storage_dir() == output_dir
+
+
+def test_env_storage_dirs_override_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test environment storage directories override persistent config."""
+    from bugcam.config import get_input_storage_dir, get_output_storage_dir
+
+    config_dir = tmp_path / ".config" / "bugcam"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.json").write_text(
+        '{"input_dir": "/config/input", "output_dir": "/config/output"}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("BUGCAM_INPUT_DIR", "/env/input")
+    monkeypatch.setenv("BUGCAM_OUTPUT_DIR", "/env/output")
+
+    assert get_input_storage_dir() == Path("/env/input")
+    assert get_output_storage_dir() == Path("/env/output")
+
+
+def test_build_saved_config_saves_storage_dirs(tmp_path: Path) -> None:
+    """Test setup persists selected storage directories."""
+    from bugcam.commands.setup import _build_saved_config
+
+    config = _build_saved_config(
+        existing_config={"input_dir": "/old/input", "output_dir": "/old/output"},
+        api_url="https://api.test/v1/",
+        api_key="key",
+        flick_id="flick",
+        dot_ids=["dot01"],
+        input_dir=tmp_path / "input",
+        output_dir=tmp_path / "output",
+    )
+
+    assert config["input_dir"] == str(tmp_path / "input")
+    assert config["output_dir"] == str(tmp_path / "output")
+
+
+def test_prompt_registration_settings_prefills_storage_dirs(tmp_path: Path) -> None:
+    """Test setup prompts use current effective storage paths as defaults."""
+    from bugcam.commands.setup import _prompt_registration_settings
+
+    defaults = {}
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    def prompt_default(label: str, *, default: object, **_: object) -> object:
+        defaults[label] = default
+        return default
+
+    with patch("bugcam.commands.setup.get_input_storage_dir", return_value=input_dir), \
+         patch("bugcam.commands.setup.get_output_storage_dir", return_value=output_dir), \
+         patch("bugcam.commands.setup.typer.prompt", side_effect=prompt_default):
+        settings = _prompt_registration_settings({})
+
+    assert defaults["Input folder"] == str(input_dir)
+    assert defaults["Output folder"] == str(output_dir)
+    assert settings["input_dir"] == input_dir.resolve()
+    assert settings["output_dir"] == output_dir.resolve()
+
+
+def test_validate_storage_dir_rejects_missing_custom_path(tmp_path: Path) -> None:
+    """Test custom storage directories must exist."""
+    from bugcam.commands.setup import _validate_storage_dir
+
+    with pytest.raises(ValueError, match="does not exist"):
+        _validate_storage_dir(tmp_path / "missing", tmp_path / "default", "Input")
+
+
+def test_validate_storage_dir_rejects_inaccessible_path(tmp_path: Path) -> None:
+    """Test storage directories must be accessible."""
+    from bugcam.commands.setup import _validate_storage_dir
+
+    selected_dir = tmp_path / "input"
+    selected_dir.mkdir()
+    with patch("bugcam.commands.setup.os.access", return_value=False):
+        with pytest.raises(ValueError, match="not accessible"):
+            _validate_storage_dir(selected_dir, tmp_path / "default", "Input")
+
+
+def test_validate_storage_dir_creates_default_path(tmp_path: Path) -> None:
+    """Test built-in default storage directories are created."""
+    from bugcam.commands.setup import _validate_storage_dir
+
+    default_dir = tmp_path / "incoming"
+
+    assert _validate_storage_dir(default_dir, default_dir, "Input") == default_dir
+    assert default_dir.is_dir()

--- a/tests/test_storage_paths.py
+++ b/tests/test_storage_paths.py
@@ -1,0 +1,154 @@
+"""Tests for runtime storage path resolution."""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def test_process_resolves_storage_dirs_at_runtime(tmp_path: Path) -> None:
+    from bugcam.commands import process as process_command
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    with patch("bugcam.commands.process.load_device_config") as mock_device_config, \
+         patch("bugcam.commands.process.get_input_storage_dir", return_value=input_dir), \
+         patch("bugcam.commands.process.get_output_storage_dir", return_value=output_dir), \
+         patch("bugcam.commands.process.resolve_bundle_provenance", return_value={"model_id": "bundle", "model_sha256": "abc123456789"}), \
+         patch("bugcam.commands.process.build_pipeline") as mock_build_pipeline, \
+         patch("bugcam.commands.process.resolve_flick_id", return_value="flick-config"):
+        mock_device_config.return_value.dot_ids = ["dot01"]
+        mock_build_pipeline.return_value = MagicMock()
+
+        process_command.process(
+            input_dir=None,
+            output_dir=None,
+            model="bundle",
+            flick_id=None,
+            classification=True,
+            continuous_tracking=True,
+        )
+
+    assert mock_build_pipeline.call_args.kwargs["input_dir"] == input_dir
+    assert mock_build_pipeline.call_args.kwargs["output_dir"] == output_dir
+
+
+def test_heartbeat_resolves_storage_dirs_at_runtime(tmp_path: Path) -> None:
+    from bugcam.commands import heartbeat as heartbeat_command
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    with patch("bugcam.commands.heartbeat._resolve_runtime_settings", return_value={"flick_id": "flick", "dot_ids": ["dot01"]}), \
+         patch("bugcam.commands.heartbeat.get_input_storage_dir", return_value=input_dir), \
+         patch("bugcam.commands.heartbeat.get_output_storage_dir", return_value=output_dir), \
+         patch("bugcam.commands.heartbeat.write_heartbeat_snapshot", return_value=output_dir / "heartbeat.json") as mock_write:
+        heartbeat_command.heartbeat(flick_id=None, dot_ids=None, input_dir=None, output_dir=None)
+
+    assert mock_write.call_args.kwargs["input_dir"] == input_dir
+    assert mock_write.call_args.kwargs["output_dir"] == output_dir
+
+
+def test_environment_resolves_output_dir_at_runtime(tmp_path: Path) -> None:
+    from bugcam.commands import environment as environment_command
+
+    output_dir = tmp_path / "output"
+
+    with patch("bugcam.commands.environment.resolve_flick_id", return_value="flick"), \
+         patch("bugcam.commands.environment.get_output_storage_dir", return_value=output_dir), \
+         patch("bugcam.commands.environment.collect_environment_reading", return_value=(output_dir / "environment.json", {"ok": True})) as mock_collect:
+        environment_command.environment(output_dir=None, device_id=None)
+
+    assert mock_collect.call_args.kwargs["output_dir"] == output_dir
+
+
+def test_upload_resolves_output_dir_at_runtime(tmp_path: Path) -> None:
+    from bugcam.commands import upload as upload_command
+
+    output_dir = tmp_path / "output"
+
+    with patch("bugcam.commands.upload.get_output_storage_dir", return_value=output_dir), \
+         patch(
+             "bugcam.commands.upload._resolve_runtime_settings",
+             return_value={"api_url": "https://api.test", "api_key": "key", "flick_id": "flick", "dot_ids": [], "s3_bucket": "bucket"},
+         ), \
+         patch("bugcam.commands.upload.watch_uploads") as mock_watch:
+        upload_command.upload(
+            output_dir=None,
+            api_url=None,
+            api_key=None,
+            bucket=None,
+            poll_interval=30,
+            delete_after_upload=True,
+            flick_id=None,
+            dot_ids=None,
+        )
+
+    assert mock_watch.call_args.args[0] == output_dir
+
+
+def test_upload_ready_results_reads_custom_output_dir(tmp_path: Path) -> None:
+    from bugcam.commands.upload import upload_ready_results
+
+    output_dir = tmp_path / "custom-output"
+    heartbeat_path = output_dir / "flick" / "heartbeats" / "20260412_120000.json"
+    heartbeat_path.parent.mkdir(parents=True)
+    heartbeat_path.write_text('{"device_id": "flick"}', encoding="utf-8")
+
+    with patch("bugcam.commands.upload.upload_file") as mock_upload_file:
+        processed_count, manifest_uploaded = upload_ready_results(
+            output_dir=output_dir,
+            api_url="https://api.test",
+            api_key="key",
+            flick_id="flick",
+            dot_ids=[],
+            delete_after_upload=False,
+            manifest_uploaded=False,
+        )
+
+    assert processed_count == 1
+    assert manifest_uploaded is False
+    assert mock_upload_file.call_args.args[2] == heartbeat_path
+    assert mock_upload_file.call_args.args[3] == "v1/flick/heartbeats/20260412_120000.json"
+
+
+def test_run_resolves_storage_dirs_at_runtime(tmp_path: Path) -> None:
+    from bugcam.commands import run as run_command
+
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    pipeline = MagicMock()
+
+    with patch("bugcam.commands.run._acquire_pid_file", return_value=tmp_path / "bugcam.pid"), \
+         patch("bugcam.commands.run._release_pid_file"), \
+         patch("bugcam.commands.run._check_time_sync", return_value=(True, "ok")), \
+         patch("bugcam.commands.run.get_input_storage_dir", return_value=input_dir), \
+         patch("bugcam.commands.run.get_output_storage_dir", return_value=output_dir), \
+         patch(
+             "bugcam.commands.run._resolve_runtime_settings",
+             return_value={"api_url": "https://api.test", "api_key": "key", "flick_id": "flick", "dot_ids": [], "s3_bucket": "bucket"},
+         ), \
+         patch("bugcam.commands.run.select_model_reference", return_value="bundle"), \
+         patch("bugcam.commands.run.resolve_bundle_provenance", return_value={"model_id": "bundle"}), \
+         patch("bugcam.commands.run.build_pipeline", return_value=pipeline) as mock_build_pipeline, \
+         patch("bugcam.commands.run.watch_uploads"), \
+         patch("bugcam.commands.run._heartbeat_loop"), \
+         patch("bugcam.commands.run._environment_loop"), \
+         patch("bugcam.commands.run.upload_ready_results"):
+        run_command.run(
+            api_url=None,
+            api_key=None,
+            flick_id=None,
+            dot_ids=None,
+            input_dir=None,
+            output_dir=None,
+            model=None,
+            mode="continuous",
+            interval=5,
+            chunk_duration=60,
+            resolution="1080x1080",
+            bucket=None,
+            upload_poll=1,
+            delete_after_upload=True,
+        )
+
+    assert mock_build_pipeline.call_args.kwargs["input_dir"] == input_dir
+    assert mock_build_pipeline.call_args.kwargs["output_dir"] == output_dir


### PR DESCRIPTION
## Summary

Add input/output storage path prompts to `bugcam setup` so operators can keep the default paths or choose mounted storage such as a USB drive.

## Changes

- Prompt for `Input folder` and `Output folder` during setup, pre-filled with the current effective absolute paths.
- Persist accepted paths as `input_dir` and `output_dir` in BugCam config.
- Resolve storage paths in this order: env var override, saved config, built-in default.
- Validate selected paths before saving config:
  - built-in defaults are created if missing
  - custom paths must already exist
  - paths must be directories, accessible, and writable via a temp write probe
- Resolve storage dirs inside command callbacks instead of import-time Typer defaults, so long-lived processes and tests cannot use stale paths.
- Fix `record single` so omitted `--output` writes under the configured output dir, not the incoming/input dir.

## Validation

Local worktree:

```text
python -m py_compile bugcam/config.py bugcam/commands/setup.py bugcam/commands/process.py bugcam/commands/heartbeat.py bugcam/commands/environment.py bugcam/commands/run.py bugcam/commands/upload.py bugcam/commands/record.py tests/test_setup.py tests/test_storage_paths.py tests/test_record.py
PYTHONPATH=/tmp/hailo-platform-stub:. /tmp/bugcam-test-venv/bin/python -m pytest tests/test_setup.py tests/test_storage_paths.py tests/test_record.py -q
36 passed
```

Raspberry Pi validation:

```text
Host: sgmit2@192.168.0.56
Python: 3.11.2
Remote temp copy: /tmp/bugcam-setup-storage-paths-test
python3 -m py_compile bugcam/config.py bugcam/commands/setup.py bugcam/commands/process.py bugcam/commands/heartbeat.py bugcam/commands/environment.py bugcam/commands/run.py bugcam/commands/upload.py bugcam/commands/record.py tests/test_setup.py tests/test_storage_paths.py tests/test_record.py
python3 -m pytest tests/test_setup.py tests/test_storage_paths.py tests/test_record.py -q
36 passed
```

Also confirmed the Pi resolves the current defaults as existing directories:

```text
input=/home/sgmit2/.local/share/bugcam/incoming exists=True is_dir=True
output=/home/sgmit2/.local/share/bugcam/outputs exists=True is_dir=True
```

The focused tests include an upload regression that places a heartbeat file under a custom output directory and verifies upload scans/uploads from that custom path.
