### PR TITLE
processing changes to optimiza hailo usage for dot data

### DIFF
--- a/bugcam/commands/upload.py
+++ b/bugcam/commands/upload.py
@@ -274,11 +274,16 @@ def upload_ready_results(
     for results_dir in _list_result_directories(output_dir):
         s3_prefix = f"v1/{results_dir.parent.name}/{results_dir.name}"
         if _is_dot_results_dir(results_dir, dot_ids):
+            # DOT: incremental upload (existing behavior)
             state = _load_uploaded_state(results_dir)
             new_state = _upload_new_dot_files(results_dir, api_url, api_key, s3_prefix, state)
             if new_state != state:
                 _save_uploaded_state(results_dir, new_state)
                 processed_count += 1
+            continue
+
+        # FLIK: only upload when classification is fully complete
+        if not (results_dir / ".done").exists():
             continue
 
         upload_directory(api_url, api_key, results_dir, s3_prefix)

--- a/bugcam/commands/upload.py
+++ b/bugcam/commands/upload.py
@@ -20,6 +20,7 @@ from bugcam.config import (
 from bugcam.s3_upload import (
     RESULTS_FILENAME,
     UPLOADED_STATE_FILENAME,
+    RateLimitError,
     upload_directory,
     upload_file,
     upload_manifest,
@@ -320,6 +321,11 @@ def watch_uploads(
             )
             consecutive_failures = 0
             stop_event.wait(poll_interval)
+        except RateLimitError as exc:
+            retry_delay = exc.retry_after if exc.retry_after is not None else min(poll_interval * 2, MAX_RETRY_DELAY_SECONDS)
+            console.print(f"[yellow]Rate limited[/yellow] — {exc}. Retrying in {retry_delay}s.")
+            consecutive_failures += 1
+            stop_event.wait(retry_delay)
         except Exception as exc:
             consecutive_failures += 1
             retry_delay = min(poll_interval * (2 ** consecutive_failures), MAX_RETRY_DELAY_SECONDS)

--- a/bugcam/config.py
+++ b/bugcam/config.py
@@ -94,6 +94,14 @@ def get_input_storage_dir() -> Path:
     return get_state_dir() / "incoming"
 
 
+def get_pending_dir() -> Path:
+    """Get the pending classification queue directory."""
+    pending_dir = os.environ.get("BUGCAM_PENDING_DIR")
+    if pending_dir:
+        return Path(pending_dir)
+    return get_state_dir() / "pending"
+
+
 def get_output_storage_dir() -> Path:
     """Get the edge26 output storage directory."""
     output_dir = os.environ.get("BUGCAM_OUTPUT_DIR")

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -398,8 +398,10 @@ class Pipeline:
             # Save crops and queue for classification
             confirmed_count = 0
             for track_id, track in result.confirmed_tracks.items():
-                # BugSpot saves crops to: output_dir/crops/{track_id}/
-                track_dir = output_dir / "crops" / track_id
+                # BugSpot saves crops using first 8 chars of track UUID
+                # track_id format: {uuid}_{timestamp} -> use first 8 chars for directory
+                base_track_id = track_id.split('-')[0]
+                track_dir = output_dir / "crops" / base_track_id
                 
                 if not track_dir.exists():
                     logger.warning(f"Track directory not found: {track_dir}")

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -237,7 +237,10 @@ class Pipeline:
     def _find_latest_background(self, dot_dir: Path):
         """Find the most recent background image in a DOT directory."""
         backgrounds = sorted(dot_dir.glob("*_background.jpg"))
-        return backgrounds[-1] if backgrounds else None
+        if backgrounds:
+            return backgrounds[-1]
+        fallback = dot_dir / "current_background.jpg"
+        return fallback if fallback.exists() else None
     
     @staticmethod
     def _deduplicate_track_id(track_id: str, results: dict) -> str:

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -585,6 +585,11 @@ class Pipeline:
             
             background = self._find_latest_background(dot_dir)
             
+            # Copy background image to output
+            if background:
+                shutil.copy2(background, output_dir / background.name)
+                logger.info(f"  Background copied: {background.name}")
+            
             # Copy any new videos to output, then delete from input
             videos_dir = dot_dir / "videos"
             if videos_dir.exists():

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -242,6 +242,47 @@ class Pipeline:
         fallback = dot_dir / "current_background.jpg"
         return fallback if fallback.exists() else None
     
+    def _process_dot_media(self, dot_dir: Path) -> None:
+        """Copy videos and backgrounds to output regardless of track readiness.
+        
+        Ensures media files reach S3 quickly even when no insect tracks
+        have been detected yet. Called on every detection worker poll.
+        """
+        try:
+            dot_id, date_str = self._parse_dot_dir_name(dot_dir.name)
+            if not dot_id:
+                return
+            
+            output_dir = self._compute_output_dir(dot_id, date_str)
+            output_dir.mkdir(parents=True, exist_ok=True)
+            copied_something = False
+            
+            videos_dir = dot_dir / "videos"
+            if videos_dir.exists():
+                dst_videos = output_dir / "videos"
+                dst_videos.mkdir(parents=True, exist_ok=True)
+                for vid in sorted(videos_dir.iterdir()):
+                    if vid.is_file() and vid.suffix == ".mp4":
+                        dst = dst_videos / vid.name
+                        if not dst.exists():
+                            shutil.copy2(vid, dst)
+                            logger.info(f"  Video copied: {vid.name}")
+                            copied_something = True
+                        vid.unlink()
+            
+            background = self._find_latest_background(dot_dir)
+            if background:
+                dst_background = output_dir / background.name
+                if not dst_background.exists():
+                    shutil.copy2(background, dst_background)
+                    logger.info(f"  Background copied: {background.name}")
+            
+            if copied_something:
+                logger.info(f"MEDIA: Copied new files from {dot_dir.name} to {output_dir.name}")
+        
+        except Exception as e:
+            logger.error(f"Failed to process media from {dot_dir.name}: {e}", exc_info=True)
+    
     @staticmethod
     def _deduplicate_track_id(track_id: str, results: dict) -> str:
         """If track_id already exists in results, append a suffix to make it unique."""
@@ -342,6 +383,7 @@ class Pipeline:
             if item_type == "video":
                 self._process_video_detection(path)
             else:
+                self._process_dot_media(path)
                 self._process_dot_directory_detection(path)
         
         # Process new videos from queue + poll for DOT directories
@@ -355,6 +397,7 @@ class Pipeline:
                 for dot_dir in self._find_dot_directories():
                     if self.stop_event.is_set():
                         break
+                    self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
                 
                 # Periodically sweep stale output directories
@@ -368,6 +411,7 @@ class Pipeline:
                 for dot_dir in self._find_dot_directories():
                     if self.stop_event.is_set():
                         break
+                    self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
                 
                 # If recording stopped, check if we're done

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -4,12 +4,14 @@ import queue
 import shutil
 import sys
 import threading
+import time
 from pathlib import Path
 from datetime import datetime
 
 from bugcam.edge26.capture import VideoRecorder
 from bugcam.edge26.processing import VideoProcessor
 from bugcam.edge26.output import ResultsWriter
+from bugcam.edge26.queue import ClassificationQueue, QueueEntry
 
 
 def setup_logging(log_dir: Path) -> None:
@@ -42,7 +44,14 @@ logger = logging.getLogger("edge26")
 
 
 class Pipeline:
-    """Main pipeline orchestrating capture and processing."""
+    """
+    Main pipeline orchestrating capture and processing.
+    
+    Architecture:
+        - Detection thread: Runs BugSpot detection/tracking (maintains tracker state)
+        - Classification thread: Runs Hailo classification (shared resource)
+        - Classification queue: Disk-based FIFO queue for both FLIK and DOT tracks
+    """
     
     def __init__(self, config: dict):
         self.config = config
@@ -50,13 +59,22 @@ class Pipeline:
         self.stop_event = threading.Event()
         self.recording_stopped = threading.Event()
         self.recorder_thread = None
-        self.processor_thread = None
+        self.detection_thread = None
+        self.classification_thread = None
         
         # Device config
         device_config = config.get("device", {})
         self.flick_id = device_config.get("flick_id", "edge26")
         self.dot_ids = device_config.get("dot_ids", [])
         self.input_storage = Path(config["paths"]["input_storage"])
+        
+        # Output paths
+        self.results_dir = Path(config["output"]["results_dir"])
+        
+        # Pending queue for classification
+        pending_dir = Path(config["paths"].get("pending_dir", 
+                         Path(config["paths"]["input_storage"]).parent / "pending"))
+        self.classification_queue = ClassificationQueue(pending_dir)
         
         # Pipeline mode
         pipeline_config = config.get("pipeline", {})
@@ -96,6 +114,7 @@ class Pipeline:
         logger.info(f"Mode:          {mode}")
         logger.info(f"Device:        {self.flick_id}")
         logger.info(f"Input storage: {config['paths']['input_storage']}")
+        logger.info(f"Pending dir:   {pending_dir}")
         if self.enable_processing:
             logger.info(f"Results dir:   {config['output']['results_dir']}")
             classify = pipeline_config.get("enable_classification", True)
@@ -196,8 +215,7 @@ class Pipeline:
     
     def _compute_output_dir(self, device_id: str, date_time: str) -> Path:
         """Compute the output directory for a device and timestamp."""
-        results_dir = Path(self.config["output"]["results_dir"])
-        return results_dir / device_id / date_time
+        return self.results_dir / device_id / date_time
     
     def _find_ready_dot_tracks(self, dot_dir: Path) -> list:
         """Find tracks within a DOT directory that have a done.txt signal."""
@@ -278,39 +296,39 @@ class Pipeline:
         self._reset_after_video = ""
     
     # ------------------------------------------------------------------
+    # Detection Thread - Runs BugSpot detection/tracking
+    # ------------------------------------------------------------------
     
-    def _processor_worker(self) -> None:
+    def _detection_worker(self) -> None:
         """
-        Worker that processes video chunks and DOT directories.
+        Worker that runs detection/tracking for videos and queues DOT tracks.
         
-        Items from input_storage are processed in chronological order
-        (sorted by name). DOT classification does NOT touch the BugSpot
-        tracker, so continuous tracking across FLICK videos is preserved
-        even when a DOT directory is processed in between.
+        Maintains continuous tracker state for FLIK videos.
+        Queues both FLIK and DOT tracks for classification.
         """
-        logger.info("Processor started")
+        logger.info("Detection worker started")
         
         # Process existing items in chronological order
         for path, item_type in self._find_existing_items():
             if self.stop_event.is_set():
                 break
             if item_type == "video":
-                self._process_video(path)
+                self._process_video_detection(path)
             else:
-                self._process_dot_directory(path)
+                self._process_dot_directory_detection(path)
         
         # Process new videos from queue + poll for DOT directories
         while not self.stop_event.is_set():
             try:
                 video_path = self.video_queue.get(timeout=1.0)
-                self._process_video(video_path)
+                self._process_video_detection(video_path)
                 self.video_queue.task_done()
             except queue.Empty:
                 # Check for new DOT directories while waiting
                 for dot_dir in self._find_dot_directories():
                     if self.stop_event.is_set():
                         break
-                    self._process_dot_directory(dot_dir)
+                    self._process_dot_directory_detection(dot_dir)
                 
                 # If recording stopped, check if we're done
                 if self.recording_stopped.is_set():
@@ -319,29 +337,35 @@ class Pipeline:
                         self._find_ready_dot_tracks(d)
                         for d in self._find_dot_directories()
                     )
-                    if remaining == 0 and not has_ready_tracks:
+                    pending_count = self.classification_queue.count()
+                    if remaining == 0 and not has_ready_tracks and pending_count == 0:
                         logger.info("Queue empty - processing complete")
                         break
                 continue
             except Exception as e:
-                logger.error(f"Processor error: {e}", exc_info=True)
+                logger.error(f"Detection error: {e}", exc_info=True)
         
-        logger.info("Processor stopped")
+        logger.info("Detection worker stopped")
     
-    def _process_video(self, video_path: Path) -> None:
-        """Process a single video file from this FLICK."""
+    def _process_video_detection(self, video_path: Path) -> None:
+        """
+        Process a FLIK video: detection/tracking only, queue crops for classification.
+        
+        Maintains tracker state for continuous tracking across videos.
+        """
         if not video_path.exists():
             logger.warning(f"Video not found: {video_path}")
             return
         
         logger.info("-" * 50)
-        logger.info(f"PROCESSING: {video_path.name}")
+        logger.info(f"DETECTION: {video_path.name}")
         logger.info("-" * 50)
         
         try:
             # Compute output directory: results_dir/flick_id/date_time/
             date_time = video_path.stem[len(self.flick_id) + 1:]
             output_dir = self._compute_output_dir(self.flick_id, date_time)
+            output_dir.mkdir(parents=True, exist_ok=True)
             
             # --- Pre-process tracker resets (continuous_tracking only) ---
             if self.continuous_tracking:
@@ -359,41 +383,65 @@ class Pipeline:
                     self.processor.reset_tracker()
                 self._last_video_date = video_date
             
-            # Process
-            results = self.processor.process_video(video_path, output_dir)
-            
-            # Write results JSON
-            output_paths = self.writer.write_results(
-                results=results,
-                output_dir=output_dir,
+            # Run BugSpot detection/tracking (Phases 1-4)
+            result = self.processor._pipeline.process_video(
+                str(video_path),
+                extract_crops=True,
+                render_composites=self.processor.output_config.get("save_composites", True),
+                save_crops_dir=str(output_dir / "crops"),
+                save_composites_dir=str(output_dir / "composites") if self.processor.output_config.get("save_composites", True) else None,
             )
             
-            # Summary
-            summary = results.get("summary", {})
-            logger.info(f"COMPLETE: {summary.get('confirmed_tracks', 0)} insects confirmed "
-                       f"({summary.get('total_tracks', 0)} total tracks)")
+            logger.info(f"  BugSpot: {len(result.confirmed_tracks)} confirmed / "
+                       f"{len(result.track_paths)} total tracks")
             
-            if output_paths.get('json'):
-                logger.info(f"Output: {output_paths['json']}")
+            # Save crops and queue for classification
+            confirmed_count = 0
+            for track_id, track in result.confirmed_tracks.items():
+                # Find the track's crop directory
+                track_dirs = list((output_dir / "crops").glob(f"{track_id}_*"))
+                if not track_dirs:
+                    # Create track directory name from track_id
+                    track_dir_name = f"{track_id}_{date_time.split('_')[-1]}" if '_' in date_time else track_id
+                    track_dir = output_dir / "crops" / track_dir_name
+                else:
+                    track_dir = track_dirs[0]
+                
+                # Extract timestamp from track directory name
+                track_timestamp = track_dir.name.rsplit("_", 1)[-1] if "_" in track_dir.name else None
+                
+                # Queue for classification
+                self.classification_queue.enqueue(
+                    entry_type="flik",
+                    source_device=self.flick_id,
+                    date=date_time[:8],  # YYYYMMDD
+                    time=track_timestamp,
+                    track_id=track_id,
+                    track_dir=track_dir,
+                    output_dir=output_dir,
+                    num_crops=len(track.crops),
+                )
+                confirmed_count += 1
             
             # Sample video: save 1 per N to output (0 = disabled)
             if self._video_sample_interval > 0:
                 self._video_batch_count += 1
-                confirmed = summary.get('confirmed_tracks', 0)
                 is_last_in_batch = self._video_batch_count >= self._video_sample_interval
                 
-                if not self._video_sample_saved and (confirmed > 0 or is_last_in_batch):
+                if not self._video_sample_saved and (confirmed_count > 0 or is_last_in_batch):
                     shutil.copy2(video_path, output_dir / "video.mp4")
                     self._video_sample_saved = True
-                    reason = "detections" if confirmed > 0 else "fallback"
+                    reason = "detections" if confirmed_count > 0 else "fallback"
                     logger.info(f"  Sample video saved ({reason})")
                 
                 if is_last_in_batch:
                     self._video_batch_count = 0
                     self._video_sample_saved = False
             
-            # Cleanup
+            # Clear detections but KEEP tracker state (continuous tracking)
             self.processor.clear_video_detections()
+            
+            # Delete processed video
             self._delete_video(video_path)
             
             # Recording-stop boundary: reset tracker after the last
@@ -403,30 +451,16 @@ class Pipeline:
                 self.processor.reset_tracker()
                 self._clear_last_recording_marker()
             
+            logger.info(f"QUEUED: {confirmed_count} tracks for classification")
+            
         except Exception as e:
             logger.error(f"Failed to process {video_path.name}: {e}", exc_info=True)
     
-    def _process_dot_directory(self, dot_dir: Path) -> None:
+    def _process_dot_directory_detection(self, dot_dir: Path) -> None:
         """
-        Process ready tracks from a DOT device directory.
+        Process DOT directory: copy crops/labels, queue for classification.
         
-        The DOT directory persists for a full day. New tracks arrive
-        continuously; only those with a done.txt signal are processed.
-        Processed tracks (crops + labels) are copied to output then
-        deleted from input. Composites are generated from crops placed
-        onto the most recent background image using label bounding boxes.
-        
-        DOT directory structure:
-            {dot_id}_{YYYYMMDD}/
-                crops/
-                    {track_id}_{HHMMSS}/
-                        frame_000042.jpg
-                        done.txt
-                labels/
-                    {track_id}.json
-                videos/
-                    {dot_id}_{YYYYMMDD}_{HHMMSS}.mp4
-                {HHMMSS}_background.jpg
+        Does NOT touch the tracker - DOT processing is independent.
         """
         try:
             dot_id, date_str = self._parse_dot_dir_name(dot_dir.name)
@@ -439,7 +473,7 @@ class Pipeline:
                 return
             
             logger.info("-" * 50)
-            logger.info(f"PROCESSING DOT: {dot_dir.name} ({len(ready_tracks)} track(s) ready)")
+            logger.info(f"DOT DETECTION: {dot_dir.name} ({len(ready_tracks)} track(s) ready)")
             logger.info("-" * 50)
             
             output_dir = self._compute_output_dir(dot_id, date_str)
@@ -458,109 +492,233 @@ class Pipeline:
                         vid.unlink()
                         logger.info(f"  Video copied: {vid.name}")
             
-            # Load existing results.json for incremental updates
-            results = None
-            if self.enable_classification:
-                results = self._load_existing_results(output_dir / "results.json")
-                results["source_device"] = dot_id
-                results["date"] = date_str
-            
-            new_tracks = 0
+            # Queue each track for classification
+            queued_count = 0
             for track_dir in ready_tracks:
                 if self.stop_event.is_set():
                     break
-                try:
-                    self._process_dot_track(
-                        dot_dir, track_dir, output_dir, background, results
-                    )
-                    new_tracks += 1
-                except Exception as e:
-                    logger.error(f"Failed to process track {track_dir.name}: {e}",
-                                exc_info=True)
-            
-            # Write updated results.json (classification mode only)
-            if new_tracks > 0 and results is not None:
-                results["processing_timestamp"] = datetime.now().isoformat()
-                results["summary"]["total_tracks"] = len(results["tracks"])
-                results["summary"]["confirmed_tracks"] = len(results["tracks"])
-                results["summary"]["total_detections"] = sum(
-                    t["num_detections"] for t in results["tracks"]
+                
+                track_dir_name = track_dir.name
+                track_id = track_dir_name.rsplit("_", 1)[0]
+                track_timestamp = track_dir_name.rsplit("_", 1)[-1] if "_" in track_dir_name else None
+                
+                # Copy crops to output
+                dst_crops = output_dir / "crops" / track_dir_name
+                dst_crops.mkdir(parents=True, exist_ok=True)
+                
+                crop_count = 0
+                for f in track_dir.iterdir():
+                    if f.name != "done.txt" and f.is_file():
+                        shutil.copy2(f, dst_crops / f.name)
+                        crop_count += 1
+                
+                # Copy label file to output
+                label_src = dot_dir / "labels" / f"{track_id}.json"
+                dst_labels = output_dir / "labels"
+                dst_labels.mkdir(parents=True, exist_ok=True)
+                if label_src.exists():
+                    shutil.copy2(label_src, dst_labels / f"{track_id}.json")
+                
+                # Queue for classification
+                self.classification_queue.enqueue(
+                    entry_type="dot",
+                    source_device=dot_id,
+                    date=date_str,
+                    time=track_timestamp,
+                    track_id=track_id,
+                    track_dir=dst_crops,
+                    output_dir=output_dir,
+                    labels_path=dst_labels / f"{track_id}.json" if label_src.exists() else None,
+                    background_path=background,
+                    num_crops=crop_count,
                 )
-                self.writer.write_results(results=results, output_dir=output_dir)
+                queued_count += 1
+                
+                # Delete processed track from input
+                shutil.rmtree(track_dir)
+                logger.debug(f"  Queued track {track_id} ({crop_count} crops)")
             
-            if new_tracks > 0:
-                classify_str = "" if self.enable_classification else " (classification disabled)"
-                logger.info(f"DOT COMPLETE: {new_tracks} new track(s) from {dot_id}{classify_str}")
+            logger.info(f"QUEUED: {queued_count} DOT tracks for classification")
         
         except Exception as e:
             logger.error(f"Failed to process DOT {dot_dir.name}: {e}", exc_info=True)
     
-    def _process_dot_track(self, dot_dir: Path, track_dir: Path,
-                           output_dir: Path, background_path, results) -> None:
+    # ------------------------------------------------------------------
+    # Classification Thread - Runs Hailo classification
+    # ------------------------------------------------------------------
+    
+    def _classification_worker(self) -> None:
         """
-        Process a single DOT track: classify, create composite, copy to output, cleanup.
+        Worker that processes classification queue (FIFO).
         
-        Args:
-            dot_dir: Parent DOT directory
-            track_dir: Track directory inside crops/ (e.g. crops/a1b2c3d4_120000/)
-            output_dir: Output results directory
-            background_path: Path to background image (or None)
-            results: Mutable results dict to append to (None if classification disabled)
+        Classifies tracks from both FLIK and DOT sources.
         """
-        track_dir_name = track_dir.name
-        track_id = track_dir_name.rsplit("_", 1)[0]
+        logger.info("Classification worker started")
         
-        logger.info(f"  Track {track_dir_name}:")
+        # Recover any pending from crash
+        self.classification_queue.recover()
         
-        # Parse timestamp from track directory name: {track_id}_{HHMMSS}
-        parts = track_dir_name.rsplit("_", 1)
-        track_timestamp = parts[1] if len(parts) == 2 else None
+        while not self.stop_event.is_set():
+            result = self.classification_queue.get_next()
+            
+            if result is None:
+                time.sleep(0.5)
+                continue
+            
+            filepath, entry = result
+            
+            try:
+                if entry.entry_type == "flik":
+                    self._classify_flik_track(entry)
+                else:
+                    self._classify_dot_track(entry)
+                
+                self.classification_queue.remove(filepath)
+                
+            except Exception as e:
+                logger.error(f"Classification failed for {filepath.name}: {e}", exc_info=True)
+                # Leave file in queue for retry (or manual intervention)
         
-        # Phase 5-6: Classify crops
-        if self.enable_classification and results is not None:
-            track_result = self.processor.classify_dot_track(
-                track_dir, track_id, track_timestamp
-            )
-            if track_result:
-                results["tracks"].append(track_result)
-                final = track_result.get("final_prediction", {})
-                logger.info(f"    {final.get('family', 'N/A')} / "
-                           f"{final.get('genus', 'N/A')} / "
-                           f"{final.get('species', 'N/A')} "
-                           f"({final.get('species_confidence', 0):.1%})")
+        logger.info("Classification worker stopped")
+    
+    def _classify_flik_track(self, entry: QueueEntry) -> None:
+        """Classify a FLIK track from queue entry."""
+        track_dir = Path(entry.track_dir)
+        output_dir = Path(entry.output_dir)
         
-        # Create composite from crops + background
-        if background_path:
-            label_path = dot_dir / "labels" / f"{track_id}.json"
+        if not track_dir.exists():
+            logger.warning(f"Track directory not found: {track_dir}")
+            return
+        
+        logger.info(f"CLASSIFY FLIK: {entry.track_id} ({entry.num_crops} crops)")
+        
+        # Load crops
+        crop_files = sorted(track_dir.glob("frame_*.jpg"))
+        if not crop_files:
+            logger.warning(f"No crops found in {track_dir}")
+            return
+        
+        # Classify
+        classifications = []
+        frames = []
+        
+        for crop_path in crop_files:
+            import cv2
+            crop = cv2.imread(str(crop_path))
+            if crop is None:
+                continue
+            
+            frame_num = int(crop_path.stem.split("_")[1])
+            classification = self.processor._classifier.classify(crop)
+            classifications.append(classification)
+            
+            frames.append({
+                "frame_number": frame_num,
+                "prediction": {
+                    "family": classification.family,
+                    "genus": classification.genus,
+                    "species": classification.species,
+                    "family_confidence": classification.family_confidence,
+                    "genus_confidence": classification.genus_confidence,
+                    "species_confidence": classification.species_confidence,
+                }
+            })
+        
+        if not classifications:
+            return
+        
+        # Hierarchical aggregation
+        final_pred = self.processor._classifier.hierarchical_aggregate(classifications)
+        if not final_pred:
+            return
+        
+        logger.info(f"  {final_pred['family']} / {final_pred['genus']} / {final_pred['species']} "
+                   f"({final_pred['species_confidence']:.1%})")
+        
+        # Load existing results
+        results_path = output_dir / "results.json"
+        results = self._load_existing_results(results_path)
+        
+        # Update results
+        track_result = {
+            "track_id": entry.track_id,
+            "timestamp": entry.time,
+            "final_prediction": final_pred,
+            "num_detections": len(classifications),
+            "frames": frames,
+        }
+        results["tracks"].append(track_result)
+        results["source_device"] = entry.source_device
+        results["date"] = entry.date
+        results["processing_timestamp"] = datetime.now().isoformat()
+        
+        # Update summary
+        results["summary"]["total_tracks"] = len(results["tracks"])
+        results["summary"]["confirmed_tracks"] = len(results["tracks"])
+        results["summary"]["total_detections"] = sum(t.get("num_detections", 0) for t in results["tracks"])
+        
+        # Write results
+        self.writer.write_results(results=results, output_dir=output_dir)
+    
+    def _classify_dot_track(self, entry: QueueEntry) -> None:
+        """Classify a DOT track from queue entry."""
+        track_dir = Path(entry.track_dir)
+        output_dir = Path(entry.output_dir)
+        
+        if not track_dir.exists():
+            logger.warning(f"Track directory not found: {track_dir}")
+            return
+        
+        logger.info(f"CLASSIFY DOT: {entry.track_id} ({entry.num_crops} crops)")
+        
+        # Classify using existing method
+        track_result = self.processor.classify_dot_track(
+            track_dir, entry.track_id, entry.time
+        )
+        
+        if not track_result:
+            return
+        
+        final = track_result.get("final_prediction", {})
+        logger.info(f"  {final.get('family', 'N/A')} / {final.get('genus', 'N/A')} / "
+                   f"{final.get('species', 'N/A')} ({final.get('species_confidence', 0):.1%})")
+        
+        # Create composite if background available
+        if entry.background_path:
+            background_path = Path(entry.background_path)
+            labels_path = Path(entry.labels_path) if entry.labels_path else None
             composite_dir = output_dir / "composites"
             composite_dir.mkdir(parents=True, exist_ok=True)
+            
+            track_dir_name = f"{entry.track_id}_{entry.time}" if entry.time else entry.track_id
+            composite_path = composite_dir / f"{track_dir_name}.jpg"
+            
             try:
-                self.processor.create_dot_composite(
-                    track_dir, background_path, label_path,
-                    composite_dir / f"{track_dir_name}.jpg"
-                )
-                logger.info(f"    Composite saved")
+                if labels_path and labels_path.exists():
+                    self.processor.create_dot_composite(
+                        track_dir, background_path, labels_path, composite_path
+                    )
+                    logger.debug(f"  Composite saved")
             except Exception as e:
-                logger.warning(f"    Could not create composite: {e}")
+                logger.warning(f"  Could not create composite: {e}")
         
-        # Copy crops to output (exclude done.txt)
-        dst_crops = output_dir / "crops" / track_dir_name
-        dst_crops.mkdir(parents=True, exist_ok=True)
-        for f in track_dir.iterdir():
-            if f.name != "done.txt" and f.is_file():
-                shutil.copy2(f, dst_crops / f.name)
+        # Load existing results
+        results_path = output_dir / "results.json"
+        results = self._load_existing_results(results_path)
         
-        # Copy label file to output, then delete from input
-        label_src = dot_dir / "labels" / f"{track_id}.json"
-        if label_src.exists():
-            dst_labels = output_dir / "labels"
-            dst_labels.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(label_src, dst_labels / f"{track_id}.json")
-            label_src.unlink()
+        # Update results
+        results["tracks"].append(track_result)
+        results["source_device"] = entry.source_device
+        results["date"] = entry.date
+        results["processing_timestamp"] = datetime.now().isoformat()
         
-        # Delete processed track from input
-        shutil.rmtree(track_dir)
-        logger.debug(f"    Deleted input: {track_dir_name}")
+        # Update summary
+        results["summary"]["total_tracks"] = len(results["tracks"])
+        results["summary"]["confirmed_tracks"] = len(results["tracks"])
+        results["summary"]["total_detections"] = sum(t.get("num_detections", 0) for t in results["tracks"])
+        
+        # Write results
+        self.writer.write_results(results=results, output_dir=output_dir)
     
     def _delete_video(self, video_path: Path) -> None:
         """Delete processed video."""
@@ -569,6 +727,10 @@ class Pipeline:
             logger.debug(f"Deleted: {video_path.name}")
         except Exception as e:
             logger.error(f"Could not delete {video_path.name}: {e}")
+    
+    # ------------------------------------------------------------------
+    # Pipeline Control
+    # ------------------------------------------------------------------
     
     def start(self) -> None:
         """Start the pipeline."""
@@ -588,15 +750,25 @@ class Pipeline:
         else:
             self.recording_stopped.set()  # No recording
         
-        # Start processor (if enabled)
+        # Start detection worker
         if self.enable_processing and self.processor:
-            self.processor_thread = threading.Thread(
-                target=self._processor_worker,
-                daemon=False,  # Non-daemon so it completes
-                name="Processor"
+            self.detection_thread = threading.Thread(
+                target=self._detection_worker,
+                daemon=False,
+                name="Detection"
             )
-            self.processor_thread.start()
-            logger.info("Processor thread started")
+            self.detection_thread.start()
+            logger.info("Detection thread started")
+            
+            # Start classification worker
+            if self.enable_classification:
+                self.classification_thread = threading.Thread(
+                    target=self._classification_worker,
+                    daemon=False,
+                    name="Classification"
+                )
+                self.classification_thread.start()
+                logger.info("Classification thread started")
         
         if self.enable_recording and self.enable_processing:
             logger.info("Pipeline running - Ctrl+C to stop recording (processing continues)")
@@ -626,6 +798,10 @@ class Pipeline:
             remaining = self.video_queue.qsize()
             if remaining > 0:
                 logger.info(f"Videos in queue: {remaining}")
+            
+            pending = self.classification_queue.count()
+            if pending > 0:
+                logger.info(f"Pending classifications: {pending}")
     
     def stop(self) -> None:
         """Stop the pipeline gracefully."""
@@ -636,11 +812,16 @@ class Pipeline:
         # Stop recorder first
         self.stop_recording()
         
-        # Stop processor
+        # Stop threads
         self.stop_event.set()
-        if self.processor_thread:
-            self.processor_thread.join(timeout=30.0)
-            logger.info("Processor stopped")
+        
+        if self.detection_thread:
+            self.detection_thread.join(timeout=30.0)
+            logger.info("Detection thread stopped")
+        
+        if self.classification_thread:
+            self.classification_thread.join(timeout=30.0)
+            logger.info("Classification thread stopped")
         
         logger.info("Pipeline stopped cleanly")
     
@@ -650,6 +831,10 @@ class Pipeline:
         if self.recorder_thread:
             self.recorder_thread.join()
         
-        # Wait for processor to finish (if running)
-        if self.processor_thread:
-            self.processor_thread.join()
+        # Wait for detection thread to finish (if running)
+        if self.detection_thread:
+            self.detection_thread.join()
+        
+        # Wait for classification thread to finish (if running)
+        if self.classification_thread:
+            self.classification_thread.join()

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -6,7 +6,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 import cv2
 
@@ -544,7 +544,7 @@ class Pipeline:
                 empty_results = {
                     "source_device": self.flick_id,
                     "date": date_time[:8],
-                    "processing_timestamp": datetime.now().isoformat(),
+                    "processing_timestamp": datetime.now(timezone.utc).isoformat(),
                     "summary": {
                         "total_detections": 0,
                         "total_tracks": 0,
@@ -585,10 +585,14 @@ class Pipeline:
             
             background = self._find_latest_background(dot_dir)
             
-            # Copy background image to output
+            # Copy background image to output, then point to the copy
+            # so the queue entry references a path that persists after
+            # the incoming DOT directory is cleaned up
             if background:
-                shutil.copy2(background, output_dir / background.name)
+                dst_background = output_dir / background.name
+                shutil.copy2(background, dst_background)
                 logger.info(f"  Background copied: {background.name}")
+                background = dst_background
             
             # Copy any new videos to output, then delete from input
             videos_dir = dot_dir / "videos"
@@ -788,7 +792,7 @@ class Pipeline:
                 results["video_info"] = detection_meta["video_info"]
             results["date"] = detection_meta.get("date", entry.date)
         results["source_device"] = entry.source_device
-        results["processing_timestamp"] = datetime.now().isoformat()
+        results["processing_timestamp"] = datetime.now(timezone.utc).isoformat()
         
         # Build per-track frame data, enriched with detection metadata
         track_frames = frames
@@ -903,7 +907,7 @@ class Pipeline:
         results["tracks"].append(track_result)
         results["source_device"] = entry.source_device
         results["date"] = entry.date
-        results["processing_timestamp"] = datetime.now().isoformat()
+        results["processing_timestamp"] = datetime.now(timezone.utc).isoformat()
         
         # Update summary
         results["summary"]["total_tracks"] = len(results["tracks"])

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -8,8 +8,10 @@ import time
 from pathlib import Path
 from datetime import datetime
 
+import cv2
+
 from bugcam.edge26.capture import VideoRecorder
-from bugcam.edge26.processing import VideoProcessor
+from bugcam.edge26.processing import VideoProcessor, HailoClassifier
 from bugcam.edge26.output import ResultsWriter
 from bugcam.edge26.queue import ClassificationQueue, QueueEntry
 
@@ -102,6 +104,11 @@ class Pipeline:
         self.recorder = self._init_recorder() if self.enable_recording else None
         self.processor = VideoProcessor(config) if self.enable_processing else None
         self.writer = ResultsWriter(config["output"]) if self.enable_processing else None
+        
+        # Eagerly initialize classifier for the classification thread
+        if self.enable_classification and self.processor:
+            self.processor._classifier = HailoClassifier(self.processor.classification_config)
+            logger.info("Hailo classifier initialized")
         
         logger.info("=" * 60)
         logger.info("EDGE26 PIPELINE INITIALIZED")
@@ -605,12 +612,15 @@ class Pipeline:
             logger.warning(f"No crops found in {track_dir}")
             return
         
+        # Ensure classifier is initialized
+        if self.processor._classifier is None:
+            self.processor._classifier = HailoClassifier(self.processor.classification_config)
+        
         # Classify
         classifications = []
         frames = []
         
         for crop_path in crop_files:
-            import cv2
             crop = cv2.imread(str(crop_path))
             if crop is None:
                 continue

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -782,7 +782,7 @@ class Pipeline:
             "track_id": track_id,
             "timestamp": entry.time,
             "final_prediction": final_pred,
-            "num_detections": track_meta.get("num_detections", len(classifications)),
+            "num_detections": len(track_frames),
             "frames": track_frames,
         }
         if track_meta.get("first_seen_seconds") is not None:

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -398,17 +398,15 @@ class Pipeline:
             # Save crops and queue for classification
             confirmed_count = 0
             for track_id, track in result.confirmed_tracks.items():
-                # Find the track's crop directory
-                track_dirs = list((output_dir / "crops").glob(f"{track_id}_*"))
-                if not track_dirs:
-                    # Create track directory name from track_id
-                    track_dir_name = f"{track_id}_{date_time.split('_')[-1]}" if '_' in date_time else track_id
-                    track_dir = output_dir / "crops" / track_dir_name
-                else:
-                    track_dir = track_dirs[0]
+                # BugSpot saves crops to: output_dir/crops/{track_id}/
+                track_dir = output_dir / "crops" / track_id
                 
-                # Extract timestamp from track directory name
-                track_timestamp = track_dir.name.rsplit("_", 1)[-1] if "_" in track_dir.name else None
+                if not track_dir.exists():
+                    logger.warning(f"Track directory not found: {track_dir}")
+                    continue
+                
+                # Extract timestamp from video filename
+                track_timestamp = date_time.split('_')[-1] if '_' in date_time else None
                 
                 # Queue for classification
                 self.classification_queue.enqueue(

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -237,14 +237,29 @@ class Pipeline:
         backgrounds = sorted(dot_dir.glob("*_background.jpg"))
         return backgrounds[-1] if backgrounds else None
     
+    @staticmethod
+    def _deduplicate_track_id(track_id: str, results: dict) -> str:
+        """If track_id already exists in results, append a suffix to make it unique."""
+        existing_ids = {t.get("track_id") for t in results.get("tracks", [])}
+        if track_id not in existing_ids:
+            return track_id
+        n = 1
+        while f"{track_id}_{n}" in existing_ids:
+            n += 1
+        deduped = f"{track_id}_{n}"
+        logger.warning(f"Track {track_id} already in results, saving as {deduped}")
+        return deduped
+
     def _load_existing_results(self, results_path: Path) -> dict:
         """Load existing results.json for incremental updates, or create a fresh structure."""
         if results_path.exists():
             try:
                 with open(results_path) as f:
                     return json.load(f)
-            except Exception:
-                pass
+            except json.JSONDecodeError:
+                logger.warning(f"Corrupt results.json, starting fresh: {results_path}")
+            except Exception as e:
+                logger.error(f"Cannot read results.json ({e}), starting fresh: {results_path}")
         return {
             "source_device": None,
             "processing_timestamp": None,
@@ -467,6 +482,54 @@ class Pipeline:
             
             logger.info(f"QUEUED: {confirmed_count} tracks for classification")
             
+            # Save detection metadata for classification thread to merge into results
+            if confirmed_count > 0:
+                detection_meta = {
+                    "source_device": self.flick_id,
+                    "date": date_time[:8],
+                    "video_file": video_path.name,
+                    "model_id": self.config.get("model", {}).get("model_id"),
+                    "video_info": {
+                        "fps": result.video_info.get("fps"),
+                        "total_frames": result.video_info.get("total_frames"),
+                        "duration_seconds": result.video_info.get("duration"),
+                    } if hasattr(result, "video_info") and result.video_info else None,
+                    "summary": {
+                        "total_detections": len(result.all_detections) if hasattr(result, "all_detections") else 0,
+                        "total_tracks": len(result.track_paths) if hasattr(result, "track_paths") else 0,
+                        "confirmed_tracks": len(result.confirmed_tracks),
+                        "unconfirmed_tracks": (len(result.track_paths) - len(result.confirmed_tracks)) if hasattr(result, "track_paths") else 0,
+                    },
+                    "tracks": {
+                        tid: {
+                            "num_detections": track.num_detections if hasattr(track, "num_detections") else None,
+                            "first_seen_seconds": track.first_frame_time if hasattr(track, "first_frame_time") else None,
+                            "last_seen_seconds": track.last_frame_time if hasattr(track, "last_frame_time") else None,
+                            "duration_seconds": track.duration if hasattr(track, "duration") else None,
+                            "topology_metrics": track.topology_metrics if hasattr(track, "topology_metrics") else None,
+                        }
+                        for tid, track in result.confirmed_tracks.items()
+                    },
+                    "frame_detections": {
+                        track_id: [
+                            {
+                                "frame_number": det.get("frame_number"),
+                                "timestamp_seconds": det.get("frame_time_seconds"),
+                                "bbox": det.get("bbox"),
+                            }
+                            for det in result.all_detections
+                            if det.get("track_id") == track_id
+                        ]
+                        for track_id in result.confirmed_tracks
+                    } if hasattr(result, "all_detections") else {},
+                }
+                meta_path = output_dir / ".detection.json"
+                meta_path.write_text(json.dumps(detection_meta, indent=2, default=str))
+                
+                # Write expected track count for completeness check
+                (output_dir / ".expected_tracks").write_text(str(confirmed_count))
+                logger.info(f"  Detection metadata saved ({confirmed_count} tracks)")
+            
         except Exception as e:
             logger.error(f"Failed to process {video_path.name}: {e}", exc_info=True)
     
@@ -553,6 +616,19 @@ class Pipeline:
                 logger.debug(f"  Queued track {track_id} ({crop_count} crops)")
             
             logger.info(f"QUEUED: {queued_count} DOT tracks for classification")
+            
+            # Write expected track count for completeness check
+            if queued_count > 0:
+                (output_dir / ".expected_tracks").write_text(str(queued_count))
+            
+            # Clean up DOT directory if empty after processing
+            try:
+                remaining = list(dot_dir.iterdir())
+                if not remaining:
+                    dot_dir.rmdir()
+                    logger.info(f"Removed empty DOT directory: {dot_dir.name}")
+            except OSError:
+                pass
         
         except Exception as e:
             logger.error(f"Failed to process DOT {dot_dir.name}: {e}", exc_info=True)
@@ -591,7 +667,12 @@ class Pipeline:
                 
             except Exception as e:
                 logger.error(f"Classification failed for {filepath.name}: {e}", exc_info=True)
-                # Leave file in queue for retry (or manual intervention)
+                should_retry = self.classification_queue.mark_failed(filepath, entry, str(e))
+                if should_retry:
+                    time.sleep(1.0)
+                else:
+                    # Permanently failed — still count as completed for .done check
+                    self._check_classification_complete(Path(entry.output_dir))
         
         logger.info("Classification worker stopped")
     
@@ -602,6 +683,7 @@ class Pipeline:
         
         if not track_dir.exists():
             logger.warning(f"Track directory not found: {track_dir}")
+            self._check_classification_complete(output_dir)
             return
         
         logger.info(f"CLASSIFY FLIK: {entry.track_id} ({entry.num_crops} crops)")
@@ -610,6 +692,7 @@ class Pipeline:
         crop_files = sorted(track_dir.glob("frame_*.jpg"))
         if not crop_files:
             logger.warning(f"No crops found in {track_dir}")
+            self._check_classification_complete(output_dir)
             return
         
         # Ensure classifier is initialized
@@ -642,11 +725,13 @@ class Pipeline:
             })
         
         if not classifications:
+            self._check_classification_complete(output_dir)
             return
         
         # Hierarchical aggregation
         final_pred = self.processor._classifier.hierarchical_aggregate(classifications)
         if not final_pred:
+            self._check_classification_complete(output_dir)
             return
         
         logger.info(f"  {final_pred['family']} / {final_pred['genus']} / {final_pred['species']} "
@@ -656,26 +741,77 @@ class Pipeline:
         results_path = output_dir / "results.json"
         results = self._load_existing_results(results_path)
         
-        # Update results
-        track_result = {
-            "track_id": entry.track_id,
-            "timestamp": entry.time,
-            "final_prediction": final_pred,
-            "num_detections": len(classifications),
-            "frames": frames,
-        }
-        results["tracks"].append(track_result)
+        # Load detection metadata to enrich results
+        detection_meta = self._load_detection_meta(output_dir)
+        
+        # Deduplicate track_id if this is a retry after crash
+        track_id = self._deduplicate_track_id(entry.track_id, results)
+        
+        # Enrich results with detection metadata (first track writes top-level fields)
+        if detection_meta and not results.get("video_file"):
+            results["video_file"] = detection_meta.get("video_file")
+            results["video_timestamp"] = detection_meta.get("video_timestamp")
+            results["model_id"] = detection_meta.get("model_id")
+            if detection_meta.get("video_info"):
+                results["video_info"] = detection_meta["video_info"]
+            results["date"] = detection_meta.get("date", entry.date)
         results["source_device"] = entry.source_device
-        results["date"] = entry.date
         results["processing_timestamp"] = datetime.now().isoformat()
         
-        # Update summary
-        results["summary"]["total_tracks"] = len(results["tracks"])
-        results["summary"]["confirmed_tracks"] = len(results["tracks"])
-        results["summary"]["total_detections"] = sum(t.get("num_detections", 0) for t in results["tracks"])
+        # Build per-track frame data, enriched with detection metadata
+        track_frames = frames
+        track_meta = detection_meta.get("tracks", {}).get(entry.track_id, {}) if detection_meta else {}
+        frame_dets = detection_meta.get("frame_detections", {}).get(entry.track_id, []) if detection_meta else []
+        
+        if frame_dets or track_meta:
+            frame_det_map = {fd["frame_number"]: fd for fd in frame_dets if fd.get("frame_number") is not None}
+            enriched_frames = []
+            for f in frames:
+                fd = frame_det_map.get(f.get("frame_number"))
+                enriched = dict(f)
+                if fd:
+                    if fd.get("timestamp_seconds") is not None:
+                        enriched["timestamp_seconds"] = fd["timestamp_seconds"]
+                    if fd.get("bbox") is not None:
+                        enriched["bbox"] = fd["bbox"]
+                enriched_frames.append(enriched)
+            track_frames = enriched_frames
+        
+        # Update results
+        track_result = {
+            "track_id": track_id,
+            "timestamp": entry.time,
+            "final_prediction": final_pred,
+            "num_detections": track_meta.get("num_detections", len(classifications)),
+            "frames": track_frames,
+        }
+        if track_meta.get("first_seen_seconds") is not None:
+            track_result["first_seen_seconds"] = track_meta["first_seen_seconds"]
+        if track_meta.get("last_seen_seconds") is not None:
+            track_result["last_seen_seconds"] = track_meta["last_seen_seconds"]
+        if track_meta.get("duration_seconds") is not None:
+            track_result["duration_seconds"] = track_meta["duration_seconds"]
+        if track_meta.get("topology_metrics") is not None:
+            track_result["topology_metrics"] = track_meta["topology_metrics"]
+        
+        results["tracks"].append(track_result)
+        
+        # Update summary from detection metadata if available, otherwise count classified tracks
+        if detection_meta and "summary" in detection_meta:
+            results["summary"]["total_detections"] = detection_meta["summary"].get("total_detections", 0)
+            results["summary"]["total_tracks"] = detection_meta["summary"].get("total_tracks", 0)
+            results["summary"]["confirmed_tracks"] = detection_meta["summary"].get("confirmed_tracks", 0)
+            results["summary"]["unconfirmed_tracks"] = detection_meta["summary"].get("unconfirmed_tracks", 0)
+        else:
+            results["summary"]["total_tracks"] = len(results["tracks"])
+            results["summary"]["confirmed_tracks"] = len(results["tracks"])
+            results["summary"]["total_detections"] = sum(t.get("num_detections", 0) for t in results["tracks"])
         
         # Write results
         self.writer.write_results(results=results, output_dir=output_dir)
+        
+        # Check if all tracks for this output directory are done
+        self._check_classification_complete(output_dir)
     
     def _classify_dot_track(self, entry: QueueEntry) -> None:
         """Classify a DOT track from queue entry."""
@@ -684,6 +820,7 @@ class Pipeline:
         
         if not track_dir.exists():
             logger.warning(f"Track directory not found: {track_dir}")
+            self._check_classification_complete(output_dir)
             return
         
         logger.info(f"CLASSIFY DOT: {entry.track_id} ({entry.num_crops} crops)")
@@ -694,6 +831,7 @@ class Pipeline:
         )
         
         if not track_result:
+            self._check_classification_complete(output_dir)
             return
         
         final = track_result.get("final_prediction", {})
@@ -723,6 +861,10 @@ class Pipeline:
         results_path = output_dir / "results.json"
         results = self._load_existing_results(results_path)
         
+        # Deduplicate track_id if this is a retry after crash
+        track_id = self._deduplicate_track_id(track_result["track_id"], results)
+        track_result["track_id"] = track_id
+        
         # Update results
         results["tracks"].append(track_result)
         results["source_device"] = entry.source_device
@@ -736,6 +878,9 @@ class Pipeline:
         
         # Write results
         self.writer.write_results(results=results, output_dir=output_dir)
+        
+        # Check if all tracks for this output directory are done
+        self._check_classification_complete(output_dir)
     
     def _delete_video(self, video_path: Path) -> None:
         """Delete processed video."""
@@ -744,6 +889,54 @@ class Pipeline:
             logger.debug(f"Deleted: {video_path.name}")
         except Exception as e:
             logger.error(f"Could not delete {video_path.name}: {e}")
+    
+    @staticmethod
+    def _load_detection_meta(output_dir: Path) -> dict:
+        """Load detection metadata sidecar if available."""
+        meta_path = output_dir / ".detection.json"
+        if meta_path.exists():
+            try:
+                return json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f"Could not read detection metadata: {e}")
+        return {}
+    
+    @staticmethod
+    def _check_classification_complete(output_dir: Path) -> None:
+        """
+        Increment completed count and check if all tracks for this dir are done.
+        
+        When detection enqueues tracks, it writes .expected_tracks with the count.
+        Each call to this method increments .completed_tracks. When
+        completed >= expected, writes .done to signal the upload thread.
+        Also called on graceful failures (missing crops, empty dirs) and
+        permanent queue failures to ensure .done is always written eventually.
+        """
+        expected_path = output_dir / ".expected_tracks"
+        if not expected_path.exists():
+            return
+        
+        try:
+            expected = int(expected_path.read_text().strip())
+        except (ValueError, OSError):
+            return
+        
+        # Atomically increment completed count
+        completed_path = output_dir / ".completed_tracks"
+        try:
+            completed = int(completed_path.read_text().strip()) + 1
+        except (ValueError, OSError):
+            completed = 1
+        completed_path.write_text(str(completed))
+        
+        if completed >= expected:
+            done_path = output_dir / ".done"
+            done_path.write_text(f"classified={completed}\nexpected={expected}\n")
+            logger.info(f"Classification complete: {completed}/{expected} tracks in {output_dir.name}")
+            expected_path.unlink(missing_ok=True)
+            completed_path.unlink(missing_ok=True)
+            detection_meta_path = output_dir / ".detection.json"
+            detection_meta_path.unlink(missing_ok=True)
     
     # ------------------------------------------------------------------
     # Pipeline Control

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -91,6 +91,8 @@ class Pipeline:
         self._video_sample_interval = pipeline_config.get("video_sample_interval", 10)
         
         # --- Tracker reset signals (continuous_tracking mode) ---
+        self._sweep_counter = 0
+        self._sweep_interval = 30
         # 1. Day-change: reset when the date in the filename changes
         self._last_video_date: str = ""
         # 2. Recording-stop: reset after the last recorded video is processed
@@ -352,6 +354,12 @@ class Pipeline:
                         break
                     self._process_dot_directory_detection(dot_dir)
                 
+                # Periodically sweep stale output directories
+                self._sweep_counter += 1
+                if self._sweep_counter >= self._sweep_interval:
+                    self._sweep_stale_directories()
+                    self._sweep_counter = 0
+                
             except queue.Empty:
                 # Check for new DOT directories while waiting
                 for dot_dir in self._find_dot_directories():
@@ -488,6 +496,7 @@ class Pipeline:
                     "source_device": self.flick_id,
                     "date": date_time[:8],
                     "video_file": video_path.name,
+                    "video_timestamp": date_time,
                     "model_id": self.config.get("model", {}).get("model_id"),
                     "video_info": {
                         "fps": result.video_info.get("fps"),
@@ -529,6 +538,24 @@ class Pipeline:
                 # Write expected track count for completeness check
                 (output_dir / ".expected_tracks").write_text(str(confirmed_count))
                 logger.info(f"  Detection metadata saved ({confirmed_count} tracks)")
+            else:
+                # No confirmed tracks — write empty results and mark done so
+                # the upload thread can discover and clean up this directory
+                empty_results = {
+                    "source_device": self.flick_id,
+                    "date": date_time[:8],
+                    "processing_timestamp": datetime.now().isoformat(),
+                    "summary": {
+                        "total_detections": 0,
+                        "total_tracks": 0,
+                        "confirmed_tracks": 0,
+                        "unconfirmed_tracks": 0,
+                    },
+                    "tracks": [],
+                }
+                self.writer.write_results(results=empty_results, output_dir=output_dir)
+                (output_dir / ".done").write_text("classified=0\nexpected=0\n")
+                logger.info(f"  No confirmed tracks, marked directory done")
             
         except Exception as e:
             logger.error(f"Failed to process {video_path.name}: {e}", exc_info=True)
@@ -763,6 +790,9 @@ class Pipeline:
         track_meta = detection_meta.get("tracks", {}).get(entry.track_id, {}) if detection_meta else {}
         frame_dets = detection_meta.get("frame_detections", {}).get(entry.track_id, []) if detection_meta else []
         
+        if detection_meta and not track_meta and not frame_dets:
+            logger.warning(f"Track {entry.track_id} not found in detection metadata, enrichment skipped")
+        
         if frame_dets or track_meta:
             frame_det_map = {fd["frame_number"]: fd for fd in frame_dets if fd.get("frame_number") is not None}
             enriched_frames = []
@@ -796,16 +826,15 @@ class Pipeline:
         
         results["tracks"].append(track_result)
         
-        # Update summary from detection metadata if available, otherwise count classified tracks
+        # Update summary: total counts from detection metadata, confirmed from actual classified tracks
         if detection_meta and "summary" in detection_meta:
             results["summary"]["total_detections"] = detection_meta["summary"].get("total_detections", 0)
             results["summary"]["total_tracks"] = detection_meta["summary"].get("total_tracks", 0)
-            results["summary"]["confirmed_tracks"] = detection_meta["summary"].get("confirmed_tracks", 0)
             results["summary"]["unconfirmed_tracks"] = detection_meta["summary"].get("unconfirmed_tracks", 0)
         else:
-            results["summary"]["total_tracks"] = len(results["tracks"])
-            results["summary"]["confirmed_tracks"] = len(results["tracks"])
             results["summary"]["total_detections"] = sum(t.get("num_detections", 0) for t in results["tracks"])
+            results["summary"]["total_tracks"] = len(results["tracks"])
+        results["summary"]["confirmed_tracks"] = len(results["tracks"])
         
         # Write results
         self.writer.write_results(results=results, output_dir=output_dir)
@@ -937,6 +966,76 @@ class Pipeline:
             completed_path.unlink(missing_ok=True)
             detection_meta_path = output_dir / ".detection.json"
             detection_meta_path.unlink(missing_ok=True)
+    
+    def _sweep_stale_directories(self) -> None:
+        """Clean up FLIK output directories that are stuck without .done markers.
+        
+        Handles two cases:
+        1. Directories with results.json but no .done and no pending classification
+           entries — likely a crash left them incomplete. If older than 30 minutes,
+           write .done so the upload thread can pick them up.
+        2. Empty directories with no results.json and no .done — created by detection
+           but never populated. Remove them if older than 10 minutes.
+        """
+        stale_threshold_seconds = 30 * 60
+        empty_threshold_seconds = 10 * 60
+        
+        try:
+            for device_dir in self.results_dir.iterdir():
+                if not device_dir.is_dir():
+                    continue
+                for output_dir in device_dir.iterdir():
+                    if not output_dir.is_dir():
+                        continue
+                    
+                    done_path = output_dir / ".done"
+                    if done_path.exists():
+                        continue
+                    
+                    results_path = output_dir / "results.json"
+                    expected_path = output_dir / ".expected_tracks"
+                    
+                    # Case 1: Has results.json but not marked done
+                    if results_path.exists() and not expected_path.exists():
+                        # No pending classification — mark done
+                        age_seconds = (datetime.now().timestamp() - output_dir.stat().st_mtime)
+                        if age_seconds > stale_threshold_seconds:
+                            done_path.write_text("swept=stale\n")
+                            logger.info(f"Swept stale directory: {output_dir.name} (no .expected_tracks, marked done)")
+                    
+                    elif results_path.exists() and expected_path.exists():
+                        # Has expected tracks but not all completed
+                        # Check if all tracks are already classified
+                        try:
+                            expected = int(expected_path.read_text().strip())
+                        except (ValueError, OSError):
+                            expected = 0
+                        completed_path = output_dir / ".completed_tracks"
+                        try:
+                            completed = int(completed_path.read_text().strip())
+                        except (ValueError, OSError):
+                            completed = 0
+                        
+                        age_seconds = (datetime.now().timestamp() - output_dir.stat().st_mtime)
+                        if age_seconds > stale_threshold_seconds and completed >= expected:
+                            done_path.write_text(f"swept=stale\ncompleted={completed}\nexpected={expected}\n")
+                            logger.info(f"Swept stale directory: {output_dir.name} (all completed but no .done)")
+                    
+                    # Case 2: Empty directory (no results.json, no classification activity)
+                    elif not results_path.exists() and not expected_path.exists():
+                        sidecar_names = {".done", ".detection.json", ".expected_tracks", ".completed_tracks", "results.json.tmp"}
+                        has_content = False
+                        for f in output_dir.rglob("*"):
+                            if f.is_file() and f.name not in sidecar_names:
+                                has_content = True
+                                break
+                        if not has_content:
+                            age_seconds = (datetime.now().timestamp() - output_dir.stat().st_mtime)
+                            if age_seconds > empty_threshold_seconds:
+                                shutil.rmtree(output_dir)
+                                logger.info(f"Removed empty stale directory: {output_dir.name}")
+        except Exception as e:
+            logger.warning(f"Error during stale directory sweep: {e}")
     
     # ------------------------------------------------------------------
     # Pipeline Control

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -323,6 +323,13 @@ class Pipeline:
                 video_path = self.video_queue.get(timeout=1.0)
                 self._process_video_detection(video_path)
                 self.video_queue.task_done()
+                
+                # Check for DOT directories after each video (interleaved processing)
+                for dot_dir in self._find_dot_directories():
+                    if self.stop_event.is_set():
+                        break
+                    self._process_dot_directory_detection(dot_dir)
+                
             except queue.Empty:
                 # Check for new DOT directories while waiting
                 for dot_dir in self._find_dot_directories():

--- a/bugcam/edge26/output/writer.py
+++ b/bugcam/edge26/output/writer.py
@@ -48,6 +48,9 @@ class ResultsWriter:
         """
         Write results JSON to an output directory.
         
+        Uses atomic write (temp file + rename) to prevent data loss
+        if the process crashes or the Pi loses power mid-write.
+        
         Args:
             results: Processing results from VideoProcessor
             output_dir: Target directory (e.g. results_dir/flick01/20260204_100000/)
@@ -58,10 +61,13 @@ class ResultsWriter:
         output_dir.mkdir(parents=True, exist_ok=True)
         output_paths = {}
         
-        # Write JSON results
         json_path = output_dir / "results.json"
-        with open(json_path, 'w') as f:
+        temp_path = json_path.with_suffix(".json.tmp")
+        
+        with open(temp_path, 'w') as f:
             json.dump(results, f, indent=2, default=str)
+        
+        temp_path.replace(json_path)
         
         output_paths['json'] = json_path
         

--- a/bugcam/edge26/output/writer.py
+++ b/bugcam/edge26/output/writer.py
@@ -16,7 +16,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Dict, List
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +105,7 @@ class ResultsWriter:
                 species_counts[species] = species_counts.get(species, 0) + 1
         
         summary_data = {
-            'generated_at': datetime.now().isoformat(),
+            'generated_at': datetime.now(timezone.utc).isoformat(),
             'total_videos': len(all_results),
             'total_tracks': total_tracks,
             'total_confirmed': total_confirmed,

--- a/bugcam/edge26/processing/processor.py
+++ b/bugcam/edge26/processing/processor.py
@@ -249,7 +249,7 @@ class VideoProcessor:
         """
         import numpy as np
         
-        BG_DARKEN = 0.35
+        BG_DARKEN = 0.85
         
         background = cv2.imread(str(background_path))
         if background is None:

--- a/bugcam/edge26/processing/processor.py
+++ b/bugcam/edge26/processing/processor.py
@@ -237,7 +237,7 @@ class VideoProcessor:
         """
         Create a composite image matching BugSpot's visual style.
         
-        Darkened background with lighten-blended crops at their bbox
+        Dimmed background with lighten-blended crops at their bbox
         positions, red path polyline through centroids, green start
         marker, and detection count label.
         

--- a/bugcam/edge26/processing/processor.py
+++ b/bugcam/edge26/processing/processor.py
@@ -9,7 +9,7 @@ import cv2
 import json
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 from bugspot import DetectionPipeline
@@ -450,7 +450,7 @@ class VideoProcessor:
             "model_id": self.model_metadata.get("model_id"),
             "video_file": video_path.name,
             "video_timestamp": video_timestamp.isoformat() if video_timestamp else None,
-            "processing_timestamp": datetime.now().isoformat(),
+            "processing_timestamp": datetime.now(timezone.utc).isoformat(),
             "video_info": {
                 "fps": vi["fps"],
                 "total_frames": vi["total_frames"],

--- a/bugcam/edge26/processing/processor.py
+++ b/bugcam/edge26/processing/processor.py
@@ -249,7 +249,7 @@ class VideoProcessor:
         """
         import numpy as np
         
-        BG_DARKEN = 0.85
+        BG_DARKEN = 0.50
         
         background = cv2.imread(str(background_path))
         if background is None:

--- a/bugcam/edge26/queue.py
+++ b/bugcam/edge26/queue.py
@@ -1,0 +1,156 @@
+"""
+Classification queue manager for interleaving FLIK and DOT classification.
+
+Provides a disk-based FIFO queue that persists across crashes and allows
+fair scheduling of classification tasks from both FLIK detection and DOT uploads.
+"""
+
+import json
+import logging
+import threading
+from dataclasses import dataclass, asdict, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QueueEntry:
+    """Represents a track queued for classification."""
+    entry_type: str                          # "flik" or "dot"
+    source_device: str
+    date: str
+    time: Optional[str]
+    track_id: str
+    track_dir: str                           # Path to crops directory
+    labels_path: Optional[str] = None        # Path to labels JSON (for DOT)
+    background_path: Optional[str] = None    # Path to background image (for DOT composite)
+    num_crops: int = 0
+    output_dir: str = ""                     # Where to write final results
+    queued_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+    
+    @classmethod
+    def from_json(cls, json_str: str) -> "QueueEntry":
+        data = json.loads(json_str)
+        return cls(**data)
+
+
+class ClassificationQueue:
+    """
+    Disk-based FIFO queue for classification tasks.
+    
+    Queues tracks from both FLIK detection and DOT uploads for
+    fair interleaved processing. Files are written to disk so
+    pending classifications survive crashes.
+    """
+    
+    def __init__(self, pending_dir: Path):
+        self.pending_dir = Path(pending_dir)
+        self.pending_dir.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+    
+    def enqueue(
+        self,
+        entry_type: str,
+        source_device: str,
+        date: str,
+        track_id: str,
+        track_dir: Path,
+        output_dir: Path,
+        time: Optional[str] = None,
+        labels_path: Optional[Path] = None,
+        background_path: Optional[Path] = None,
+        num_crops: int = 0,
+    ) -> Path:
+        """Queue a track for classification."""
+        entry = QueueEntry(
+            entry_type=entry_type,
+            source_device=source_device,
+            date=date,
+            time=time,
+            track_id=track_id,
+            track_dir=str(track_dir),
+            labels_path=str(labels_path) if labels_path else None,
+            background_path=str(background_path) if background_path else None,
+            num_crops=num_crops,
+            output_dir=str(output_dir),
+        )
+        
+        with self._lock:
+            # Use timestamp in filename for uniqueness and FIFO ordering
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            filename = f"{source_device}_{date}_{timestamp}_{track_id}.json"
+            filepath = self.pending_dir / filename
+            filepath.write_text(entry.to_json())
+            logger.debug(f"Queued for classification: {filepath.name}")
+        
+        return filepath
+    
+    def get_next(self) -> Optional[tuple[Path, QueueEntry]]:
+        """Get oldest pending entry (FIFO by mtime)."""
+        with self._lock:
+            files = sorted(
+                self.pending_dir.glob("*.json"),
+                key=lambda p: p.stat().st_mtime
+            )
+            
+            if not files:
+                return None
+            
+            filepath = files[0]
+            try:
+                entry = QueueEntry.from_json(filepath.read_text())
+                logger.debug(f"Retrieved from queue: {filepath.name}")
+                return filepath, entry
+            except Exception as e:
+                logger.error(f"Failed to read queue entry {filepath}: {e}")
+                # Move corrupted file aside
+                corrupted = filepath.with_suffix(".corrupted")
+                filepath.rename(corrupted)
+                logger.warning(f"Moved corrupted file to {corrupted}")
+                return None
+    
+    def remove(self, filepath: Path) -> None:
+        """Remove processed entry from queue."""
+        with self._lock:
+            if filepath.exists():
+                filepath.unlink()
+                logger.debug(f"Removed from queue: {filepath.name}")
+    
+    def count(self) -> int:
+        """Count pending entries."""
+        return len(list(self.pending_dir.glob("*.json")))
+    
+    def recover(self) -> int:
+        """Recover pending entries after crash. Returns count."""
+        count = self.count()
+        if count > 0:
+            logger.info(f"Recovered {count} pending classification(s) from {self.pending_dir}")
+        return count
+    
+    def get_pending_entries(self) -> list[tuple[Path, QueueEntry]]:
+        """Get all pending entries sorted by mtime (for debugging/inspection)."""
+        entries = []
+        with self._lock:
+            files = sorted(
+                self.pending_dir.glob("*.json"),
+                key=lambda p: p.stat().st_mtime
+            )
+            for filepath in files:
+                try:
+                    entry = QueueEntry.from_json(filepath.read_text())
+                    entries.append((filepath, entry))
+                except Exception:
+                    pass
+        return entries
+
+
+def get_pending_dir() -> Path:
+    """Get the pending classification queue directory."""
+    from bugcam.config import get_state_dir
+    return get_state_dir() / "pending"

--- a/bugcam/edge26/queue.py
+++ b/bugcam/edge26/queue.py
@@ -3,6 +3,7 @@ Classification queue manager for interleaving FLIK and DOT classification.
 
 Provides a disk-based FIFO queue that persists across crashes and allows
 fair scheduling of classification tasks from both FLIK detection and DOT uploads.
+Failed entries are moved to a dead-letter directory with a max count limit.
 """
 
 import json
@@ -14,6 +15,9 @@ from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+MAX_FAILED_ENTRIES = 50
 
 
 @dataclass
@@ -30,30 +34,40 @@ class QueueEntry:
     num_crops: int = 0
     output_dir: str = ""                     # Where to write final results
     queued_at: str = field(default_factory=lambda: datetime.now().isoformat())
-    
+    retry_count: int = 0
+    last_error: Optional[str] = None
+
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2)
-    
+
     @classmethod
     def from_json(cls, json_str: str) -> "QueueEntry":
         data = json.loads(json_str)
-        return cls(**data)
+        known = {f.name for f in cls.__dataclass_fields__.values()}
+        filtered = {k: v for k, v in data.items() if k in known}
+        return cls(**filtered)
 
 
 class ClassificationQueue:
     """
     Disk-based FIFO queue for classification tasks.
-    
+
     Queues tracks from both FLIK detection and DOT uploads for
     fair interleaved processing. Files are written to disk so
     pending classifications survive crashes.
+
+    Failed entries are moved to a 'failed/' subdirectory after
+    MAX_RETRIES attempts. The failed directory is pruned to
+    MAX_FAILED_ENTRIES entries on a FIFO (oldest-first) basis.
     """
-    
+
     def __init__(self, pending_dir: Path):
         self.pending_dir = Path(pending_dir)
         self.pending_dir.mkdir(parents=True, exist_ok=True)
+        self.failed_dir = self.pending_dir / "failed"
+        self.failed_dir.mkdir(exist_ok=True)
         self._lock = threading.Lock()
-    
+
     def enqueue(
         self,
         entry_type: str,
@@ -80,17 +94,18 @@ class ClassificationQueue:
             num_crops=num_crops,
             output_dir=str(output_dir),
         )
-        
+
         with self._lock:
-            # Use timestamp in filename for uniqueness and FIFO ordering
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             filename = f"{source_device}_{date}_{timestamp}_{track_id}.json"
             filepath = self.pending_dir / filename
-            filepath.write_text(entry.to_json())
+            temp_path = self.pending_dir / f".tmp_{filename}"
+            temp_path.write_text(entry.to_json())
+            temp_path.rename(filepath)
             logger.debug(f"Queued for classification: {filepath.name}")
-        
+
         return filepath
-    
+
     def get_next(self) -> Optional[tuple[Path, QueueEntry]]:
         """Get oldest pending entry (FIFO by mtime)."""
         with self._lock:
@@ -98,10 +113,10 @@ class ClassificationQueue:
                 self.pending_dir.glob("*.json"),
                 key=lambda p: p.stat().st_mtime
             )
-            
+
             if not files:
                 return None
-            
+
             filepath = files[0]
             try:
                 entry = QueueEntry.from_json(filepath.read_text())
@@ -109,30 +124,73 @@ class ClassificationQueue:
                 return filepath, entry
             except Exception as e:
                 logger.error(f"Failed to read queue entry {filepath}: {e}")
-                # Move corrupted file aside
                 corrupted = filepath.with_suffix(".corrupted")
                 filepath.rename(corrupted)
                 logger.warning(f"Moved corrupted file to {corrupted}")
                 return None
-    
+
     def remove(self, filepath: Path) -> None:
         """Remove processed entry from queue."""
         with self._lock:
             if filepath.exists():
                 filepath.unlink()
                 logger.debug(f"Removed from queue: {filepath.name}")
-    
+
+    def mark_failed(self, filepath: Path, entry: QueueEntry, error: str) -> bool:
+        """Handle a failed classification attempt.
+
+        Increments retry count on the entry. If MAX_RETRIES is exceeded,
+        moves the entry to the failed/ directory. Otherwise, rewrites it
+        with the updated retry count so it will be retried.
+
+        Returns True if entry should be retried, False if moved to failed/.
+        """
+        entry.retry_count += 1
+        entry.last_error = error[:500]
+
+        if entry.retry_count >= MAX_RETRIES:
+            with self._lock:
+                failed_path = self.failed_dir / filepath.name
+                try:
+                    filepath.rename(failed_path)
+                except FileNotFoundError:
+                    pass
+                logger.error(f"Entry {filepath.name} exceeded {MAX_RETRIES} retries, "
+                            f"moved to failed/: {error}")
+            self._prune_failed()
+            return False
+
+        with self._lock:
+            if filepath.exists():
+                filepath.write_text(entry.to_json())
+        logger.warning(f"Entry {filepath.name} failed "
+                      f"(retry {entry.retry_count}/{MAX_RETRIES}): {error}")
+        return True
+
+    def _prune_failed(self) -> None:
+        """Remove oldest failed entries beyond MAX_FAILED_ENTRIES."""
+        failed_files = sorted(
+            self.failed_dir.glob("*.json"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for old_file in failed_files[MAX_FAILED_ENTRIES:]:
+            old_file.unlink()
+            logger.debug(f"Pruned old failed entry: {old_file.name}")
+
     def count(self) -> int:
         """Count pending entries."""
-        return len(list(self.pending_dir.glob("*.json")))
-    
+        with self._lock:
+            return len(list(self.pending_dir.glob("*.json")))
+
     def recover(self) -> int:
         """Recover pending entries after crash. Returns count."""
         count = self.count()
         if count > 0:
             logger.info(f"Recovered {count} pending classification(s) from {self.pending_dir}")
+        self._prune_failed()
         return count
-    
+
     def get_pending_entries(self) -> list[tuple[Path, QueueEntry]]:
         """Get all pending entries sorted by mtime (for debugging/inspection)."""
         entries = []

--- a/bugcam/edge26/queue.py
+++ b/bugcam/edge26/queue.py
@@ -33,7 +33,7 @@ class QueueEntry:
     background_path: Optional[str] = None    # Path to background image (for DOT composite)
     num_crops: int = 0
     output_dir: str = ""                     # Where to write final results
-    queued_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    queued_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
     retry_count: int = 0
     last_error: Optional[str] = None
 

--- a/bugcam/edge26/queue.py
+++ b/bugcam/edge26/queue.py
@@ -10,7 +10,7 @@ import json
 import logging
 import threading
 from dataclasses import dataclass, asdict, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 

--- a/bugcam/s3_upload.py
+++ b/bugcam/s3_upload.py
@@ -10,12 +10,21 @@ import requests
 RESULTS_FILENAME = "results.json"
 MANIFEST_FILENAME = "manifest.json"
 UPLOADED_STATE_FILENAME = ".uploaded"
+DETECTION_META_FILENAME = ".detection.json"
+EXPECTED_TRACKS_FILENAME = ".expected_tracks"
+DONE_MARKER_FILENAME = ".done"
 REQUEST_TIMEOUT_SECONDS = 30
 UPLOAD_TIMEOUT_SECONDS = 300
 
 
 def _iter_upload_files(local_dir: Path) -> list[Path]:
-    files = [path for path in sorted(local_dir.rglob("*")) if path.is_file() and path.name != UPLOADED_STATE_FILENAME]
+    skip_names = {
+        UPLOADED_STATE_FILENAME,
+        DETECTION_META_FILENAME,
+        EXPECTED_TRACKS_FILENAME,
+        DONE_MARKER_FILENAME,
+    }
+    files = [path for path in sorted(local_dir.rglob("*")) if path.is_file() and path.name not in skip_names]
     return [path for path in files if path.name != RESULTS_FILENAME] + [path for path in files if path.name == RESULTS_FILENAME]
 
 

--- a/bugcam/s3_upload.py
+++ b/bugcam/s3_upload.py
@@ -12,6 +12,7 @@ MANIFEST_FILENAME = "manifest.json"
 UPLOADED_STATE_FILENAME = ".uploaded"
 DETECTION_META_FILENAME = ".detection.json"
 EXPECTED_TRACKS_FILENAME = ".expected_tracks"
+COMPLETED_TRACKS_FILENAME = ".completed_tracks"
 DONE_MARKER_FILENAME = ".done"
 REQUEST_TIMEOUT_SECONDS = 30
 UPLOAD_TIMEOUT_SECONDS = 300
@@ -22,6 +23,7 @@ def _iter_upload_files(local_dir: Path) -> list[Path]:
         UPLOADED_STATE_FILENAME,
         DETECTION_META_FILENAME,
         EXPECTED_TRACKS_FILENAME,
+        COMPLETED_TRACKS_FILENAME,
         DONE_MARKER_FILENAME,
     }
     files = [path for path in sorted(local_dir.rglob("*")) if path.is_file() and path.name not in skip_names]

--- a/bugcam/s3_upload.py
+++ b/bugcam/s3_upload.py
@@ -18,6 +18,14 @@ REQUEST_TIMEOUT_SECONDS = 30
 UPLOAD_TIMEOUT_SECONDS = 300
 
 
+class RateLimitError(Exception):
+    """Raised when the API returns 429 Too Many Requests."""
+
+    def __init__(self, retry_after: int | None = None, message: str = ""):
+        self.retry_after = retry_after
+        super().__init__(message or f"Rate limited{f', retry after {retry_after}s' if retry_after else ''}")
+
+
 def _iter_upload_files(local_dir: Path) -> list[Path]:
     skip_names = {
         UPLOADED_STATE_FILENAME,
@@ -37,6 +45,14 @@ def get_upload_url(api_url: str, api_key: str, s3_key: str) -> str:
         headers={"X-Api-Key": api_key},
         timeout=REQUEST_TIMEOUT_SECONDS,
     )
+    if response.status_code == 429:
+        retry_after = None
+        if "Retry-After" in response.headers:
+            try:
+                retry_after = int(response.headers["Retry-After"])
+            except (ValueError, TypeError):
+                pass
+        raise RateLimitError(retry_after=retry_after)
     response.raise_for_status()
     payload = response.json()
     upload_url = payload.get("upload_url")
@@ -53,6 +69,14 @@ def upload_bytes(api_url: str, api_key: str, data: bytes, s3_key: str, content_t
         headers={"Content-Type": content_type},
         timeout=UPLOAD_TIMEOUT_SECONDS,
     )
+    if response.status_code == 429:
+        retry_after = None
+        if "Retry-After" in response.headers:
+            try:
+                retry_after = int(response.headers["Retry-After"])
+            except (ValueError, TypeError):
+                pass
+        raise RateLimitError(retry_after=retry_after)
     response.raise_for_status()
 
 
@@ -61,6 +85,14 @@ def upload_file(api_url: str, api_key: str, local_path: Path, s3_key: str) -> No
     upload_url = get_upload_url(api_url, api_key, s3_key)
     with local_path.open("rb") as fh:
         response = requests.put(upload_url, data=fh, timeout=UPLOAD_TIMEOUT_SECONDS)
+    if response.status_code == 429:
+        retry_after = None
+        if "Retry-After" in response.headers:
+            try:
+                retry_after = int(response.headers["Retry-After"])
+            except (ValueError, TypeError):
+                pass
+        raise RateLimitError(retry_after=retry_after)
     response.raise_for_status()
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -51,9 +51,11 @@ def test_video_processor_passes_ratio_config_to_bugspot() -> None:
 
 def test_dot_done_signal_processing_uses_existing_track_crops(tmp_path: Path) -> None:
     from bugcam.edge26 import main as edge26_main
+    from bugcam.edge26.queue import QueueEntry
 
     input_dir = tmp_path / "input"
     output_dir = tmp_path / "output"
+    pending_dir = tmp_path / "pending"
     track_dir = input_dir / "dot01_20260417" / "crops" / "track-a_123456"
     labels_dir = input_dir / "dot01_20260417" / "labels"
     videos_dir = input_dir / "dot01_20260417" / "videos"
@@ -64,33 +66,38 @@ def test_dot_done_signal_processing_uses_existing_track_crops(tmp_path: Path) ->
     (track_dir / "frame_000001.jpg").write_bytes(b"crop")
     (labels_dir / "track-a.json").write_text("{}", encoding="utf-8")
     (videos_dir / "dot01_20260417_123456.mp4").write_bytes(b"video")
-    track_result = {"track_id": "track-a", "num_detections": 1, "final_prediction": {}}
 
-    with patch.object(edge26_main, "VideoProcessor") as processor_cls, \
-         patch.object(edge26_main, "ResultsWriter") as writer_cls:
-        processor_cls.return_value.classify_dot_track.return_value = track_result
+    with patch.object(edge26_main, "VideoProcessor") as processor_cls:
         pipeline = edge26_main.Pipeline(
             {
                 "device": {"flick_id": "flick01", "dot_ids": ["dot01"]},
-                "paths": {"input_storage": str(input_dir)},
+                "paths": {"input_storage": str(input_dir), "pending_dir": str(pending_dir)},
                 "pipeline": {"enable_recording": False, "enable_processing": True, "enable_classification": True},
                 "output": {"results_dir": str(output_dir)},
             }
         )
-        pipeline._process_dot_directory(input_dir / "dot01_20260417")
+        pipeline._process_dot_directory_detection(input_dir / "dot01_20260417")
 
-    processor_cls.return_value.classify_dot_track.assert_called_once_with(track_dir, "track-a", "123456")
-    writer_cls.return_value.write_results.assert_called_once()
-    written_results = writer_cls.return_value.write_results.call_args.kwargs["results"]
-    assert written_results["source_device"] == "dot01"
-    assert written_results["summary"]["confirmed_tracks"] == 1
-    assert written_results["tracks"] == [track_result]
-    assert (output_dir / "dot01" / "20260417" / "crops" / "track-a_123456" / "frame_000001.jpg").exists()
-    assert (output_dir / "dot01" / "20260417" / "labels" / "track-a.json").exists()
-    assert (output_dir / "dot01" / "20260417" / "videos" / "dot01_20260417_123456.mp4").exists()
+    # Verify track was queued for classification
+    assert pipeline.classification_queue.count() == 1
+    entries = pipeline.classification_queue.get_pending_entries()
+    assert len(entries) == 1
+    filepath, entry = entries[0]
+    assert entry.entry_type == "dot"
+    assert entry.source_device == "dot01"
+    assert entry.track_id == "track-a"
+    assert entry.time == "123456"
+    assert entry.num_crops == 1
+    # Track should be deleted from input after queuing
     assert not track_dir.exists()
-    assert not (labels_dir / "track-a.json").exists()
-    assert not (videos_dir / "dot01_20260417_123456.mp4").exists()
+    # Crops should be copied to output
+    assert (output_dir / "dot01" / "20260417" / "crops" / "track-a_123456" / "frame_000001.jpg").exists()
+    # Labels should be copied to output
+    assert (output_dir / "dot01" / "20260417" / "labels" / "track-a.json").exists()
+    # Expected tracks marker should be written
+    expected_path = output_dir / "dot01" / "20260417" / ".expected_tracks"
+    assert expected_path.exists()
+    assert expected_path.read_text().strip() == "1"
 
 
 def test_build_edge26_config_resolves_paths(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
# Separate Detection and Classification Pipeline
## Summary
Refactors the pipeline into two threads: **detection** (BugSpot + tracking) and **classification** (Hailo). Both FLIK and DOT tracks now share a FIFO queue, preventing DOT starvation.
## Changes
| File | Description |
|------|-------------|
| `bugcam/edge26/queue.py` | NEW: Disk-based FIFO queue for classification tasks |
| `bugcam/edge26/main.py` | Split into `_detection_worker` + `_classification_worker` threads |
| `bugcam/config.py` | Added `get_pending_dir()` |

## Test
```bash
# Start bugcam
bugcam run
# Verify both threads start
# Expected logs:
#   "Detection worker started"
#   "Classification worker started"
# Check pending queue
ls ~/.local/share/bugcam/pending/
# Verify fair scheduling
# Both FLIK and DOT tracks should appear in queue
Verification
- [ ] Detection thread processes FLIK videos
- [ ] Classification thread processes pending queue
- [ ] DOT tracks are queued and processed (no starvation)
- [ ] Continuous tracking preserved across videos
- [ ] Crash recovery: pending tracks reprocessed on restart