### PR TITLE
Fixes/video cleanup

### DIFF
--- a/bugcam/commands/autostart.py
+++ b/bugcam/commands/autostart.py
@@ -100,7 +100,7 @@ def enable(
     length: int = typer.Option(30, "--length", "-l", help="Chunk duration in seconds"),
     resolution: str = typer.Option("3840x2160", "--resolution", help="Recording resolution in WxH format"),
     fps: int = typer.Option(15, "--fps", help="Recording frame rate"),
-    poll_interval: int = typer.Option(30, "--poll-interval", help="Upload poll interval in seconds"),
+    poll_interval: int = typer.Option(3600, "--poll-interval", help="Upload poll interval in seconds"),
     delete_after_upload: bool = typer.Option(
         True,
         "--delete-after-upload/--no-delete-after-upload",

--- a/bugcam/commands/run.py
+++ b/bugcam/commands/run.py
@@ -56,8 +56,11 @@ def _heartbeat_loop(
         if pollen is not None:
             # Heartbeats are telemetry, not durable artifacts; shipped through the
             # spooler for now, though file-vs-real-time-POST delivery is still open.
-            pollen.enqueue_set([path], device=flick_id, kind="heartbeat")  # staged; our copy is done
-            path.unlink(missing_ok=True)
+            try:
+                pollen.enqueue_set([path], device=flick_id, kind="heartbeat")  # staged; our copy is done
+                path.unlink(missing_ok=True)
+            except Exception:
+                logger.exception("heartbeat enqueue failed (will retry next interval): %s", path.name)
         stop_event.wait(interval)
 
 
@@ -78,6 +81,7 @@ def _environment_loop(
         except Exception as exc:
             if not warning_emitted:
                 console.print(f"[yellow]Environment sensor warning[/yellow] {exc}")
+                logger.warning("environment sensor/enqueue warning: %s: %s", type(exc).__name__, exc)
                 warning_emitted = True
         stop_event.wait(ENVIRONMENT_INTERVAL_SECONDS)
 
@@ -252,7 +256,7 @@ def run(
     resolution: str = typer.Option("1080x1080", "--resolution", help="Recording resolution in WxH format"),
     bitrate: int = typer.Option(20_000_000, "--bitrate", help="H.264 encoder bitrate in bps (hardware encoding only)"),
     bucket: str | None = typer.Option(None, "--bucket", help="Configured output bucket"),
-    upload_poll: int = typer.Option(30, "--upload-poll", help="Seconds between upload polls; with --archive-batch this is also the batch cadence (one tar per device per poll) (config: upload_poll_interval)"),
+    upload_poll: int = typer.Option(3600, "--upload-poll", help="Seconds between upload polls; with --archive-batch this is also the batch cadence (one tar per device per poll) (config: upload_poll_interval)"),
     heartbeat_interval: float | None = typer.Option(None, "--heartbeat-interval", help="Seconds between heartbeat snapshots (config: heartbeat_interval, default 60)"),
     with_receiver: bool = typer.Option(
         True,
@@ -321,6 +325,10 @@ def run(
                 delete_after_upload=delete_after_upload,
             )
             console.print(f"[dim]Upload[/dim] enabled (batch={pollen_settings['batch']})")
+            logger.info(
+                "upload enabled (batch=%s, poll_interval=%s, videos_per_tick=%s)",
+                pollen_settings["batch"], pollen_settings["poll_interval"], pollen_settings["videos_per_tick"],
+            )
 
             # The manifest is a fixed-key object the queue does not own; ship it once
             # at startup. A missing manifest is non-fatal -- the backend resolves
@@ -335,8 +343,10 @@ def run(
                 pollen_instance.upload_now(manifest, "v1/manifest.json", "application/json")
             except Exception as exc:  # noqa: BLE001
                 console.print(f"[yellow]Manifest upload failed[/yellow] {exc} (non-fatal)")
+                logger.warning("manifest upload failed (non-fatal): %s: %s", type(exc).__name__, exc)
         else:
             console.print("[yellow]Uploads disabled[/yellow] (--no-upload)")
+            logger.warning("uploads disabled for this run (--no-upload) -- no artifact will reach S3")
 
         selected_model = select_model_reference(model)
         provenance = resolve_bundle_provenance(selected_model)

--- a/bugcam/commands/run.py
+++ b/bugcam/commands/run.py
@@ -286,6 +286,13 @@ def run(
         "--archive-batch/--no-archive-batch",
         help="Bundle outputs into per-device tar archives instead of per-object uploads; cadence follows --upload-poll (config: archive_batch)",
     ),
+    record: bool = typer.Option(
+        True,
+        "--record/--no-record",
+        help="Record from the camera; --no-record watches --input-dir as a drop "
+             "folder instead, processing injected videos/DOT dirs (inject with mv, "
+             "not cp: a file mid-copy can be picked up truncated)",
+    ),
 ) -> None:
     """Run recording, processing, uploading, and one-minute heartbeat emission."""
     if mode not in {"continuous", "interval"}:
@@ -354,6 +361,9 @@ def run(
             console.print(f"[dim]Using model[/dim] {provenance['model_id']}")
         console.print(f"[cyan]Running[/cyan] flick={settings['flick_id']} dots={settings['dot_ids'] or '[]'}")
         console.print(f"[dim]Model[/dim] {provenance['model_id']}")
+        if not record:
+            console.print(f"[yellow]Recording disabled[/yellow] (--no-record); watching {input_dir} for injected input")
+            logger.info("recording disabled for this run (--no-record); processing injected input only")
 
         on_result_ready = None
         on_log_complete = None
@@ -382,6 +392,8 @@ def run(
             resolution=parsed_resolution,
             bitrate=bitrate,
             detection_in_subprocess=detection_in_subprocess,
+            enable_recording=record,
+            watch_input=not record,
             detection_config_path=detection_config,
             on_result_ready=on_result_ready,
             on_log_complete=on_log_complete,

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -143,8 +143,8 @@ class Pipeline:
         self._video_sample_interval = pipeline_config.get("video_sample_interval", 10)
         
         # --- Tracker reset signals (continuous_tracking mode) ---
-        self._sweep_counter = 0
-        self._sweep_interval = 30
+        self._last_sweep_monotonic = time.monotonic()
+        self._sweep_interval_seconds = 300.0
         # 1. Day-change: reset when the date in the filename changes
         self._last_video_date: str = ""
         # 2. Recording-stop: reset after the last recorded video is processed
@@ -508,12 +508,8 @@ class Pipeline:
                     self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
                 
-                # Periodically sweep stale output directories
-                self._sweep_counter += 1
-                if self._sweep_counter >= self._sweep_interval:
-                    self._sweep_stale_directories()
-                    self._sweep_counter = 0
-                
+                self._maybe_sweep_stale_directories()
+
             except queue.Empty:
                 # Check for new DOT directories while waiting
                 for dot_dir in self._find_dot_directories():
@@ -521,7 +517,9 @@ class Pipeline:
                         break
                     self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
-                
+
+                self._maybe_sweep_stale_directories()
+
                 # If recording stopped, check if we're done
                 if self.recording_stopped.is_set():
                     remaining = self.video_queue.qsize()
@@ -587,33 +585,26 @@ class Pipeline:
             logger.info(f"  BugSpot: {len(result.confirmed_tracks)} confirmed / "
                        f"{len(result.track_paths)} total tracks")
             
-            # Save crops and queue for classification
-            confirmed_count = 0
+            # Collect confirmed tracks whose crops made it to disk. Enqueueing
+            # is deferred until .expected_tracks is on disk (below): the
+            # classification worker can finish a fast track before detection
+            # gets around to writing the count, in which case
+            # _check_classification_complete silently no-ops and the directory
+            # never reaches .done.
+            track_timestamp = date_time.split('_')[-1] if '_' in date_time else None
+            queueable_tracks = []
             for track_id, track in result.confirmed_tracks.items():
                 # BugSpot saves crops using first 8 chars of track UUID
                 # track_id format: {uuid}_{timestamp} -> use first 8 chars for directory
                 base_track_id = track_id.split('-')[0]
                 track_dir = output_dir / "crops" / base_track_id
-                
+
                 if not track_dir.exists():
                     logger.warning(f"Track directory not found: {track_dir}")
                     continue
-                
-                # Extract timestamp from video filename
-                track_timestamp = date_time.split('_')[-1] if '_' in date_time else None
-                
-                # Queue for classification
-                self.classification_queue.enqueue(
-                    entry_type="flik",
-                    source_device=self.flick_id,
-                    date=date_time[:8],  # YYYYMMDD
-                    time=track_timestamp,
-                    track_id=track_id,
-                    track_dir=track_dir,
-                    output_dir=output_dir,
-                    num_crops=len(track.crops),
-                )
-                confirmed_count += 1
+
+                queueable_tracks.append((track_id, track, track_dir))
+            confirmed_count = len(queueable_tracks)
             
             # Sample video: save 1 per N to output (0 = disabled)
             if self._video_sample_interval > 0:
@@ -642,8 +633,6 @@ class Pipeline:
                 logger.info("Last recorded video processed, resetting tracker")
                 self.processor.reset_tracker()
                 self._clear_last_recording_marker()
-            
-            logger.info(f"QUEUED: {confirmed_count} tracks for classification")
             
             # Save detection metadata for classification thread to merge into results
             if confirmed_count > 0:
@@ -696,9 +685,23 @@ class Pipeline:
                 meta_path = output_dir / ".detection.json"
                 meta_path.write_text(json.dumps(detection_meta, indent=2, default=str))
                 
-                # Write expected track count for completeness check
+                # Write expected track count for completeness check -- must be
+                # on disk before the first track is enqueued
                 (output_dir / ".expected_tracks").write_text(str(confirmed_count))
                 logger.info(f"  Detection metadata saved ({confirmed_count} tracks)")
+
+                for track_id, track, track_dir in queueable_tracks:
+                    self.classification_queue.enqueue(
+                        entry_type="flik",
+                        source_device=self.flick_id,
+                        date=date_time[:8],  # YYYYMMDD
+                        time=track_timestamp,
+                        track_id=track_id,
+                        track_dir=track_dir,
+                        output_dir=output_dir,
+                        num_crops=len(track.crops),
+                    )
+                logger.info(f"QUEUED: {confirmed_count} tracks for classification")
             else:
                 # No confirmed tracks — write empty results and mark done so
                 # the upload thread can discover and clean up this directory
@@ -785,6 +788,11 @@ class Pipeline:
                 if label_src.exists():
                     shutil.copy2(label_src, dst_labels / f"{track_id}.json")
 
+                # One track per dir: complete-on-single, so .done fires immediately.
+                # Must be on disk before the enqueue, or a fast classification
+                # no-ops the completion check and the dir never reaches .done.
+                (track_output_dir / ".expected_tracks").write_text("1")
+
                 # Queue for classification. track_id stays bare: the backend
                 # reconstructs crop/composite keys as {track_id}_{timestamp} and keys
                 # the tracks table on (device_id, timestamp), not track_id.
@@ -800,8 +808,6 @@ class Pipeline:
                     background_path=track_background,
                     num_crops=crop_count,
                 )
-                # One track per dir: complete-on-single, so .done fires immediately.
-                (track_output_dir / ".expected_tracks").write_text("1")
                 queued_count += 1
 
                 # Delete processed track from input
@@ -841,14 +847,22 @@ class Pipeline:
         self.classification_queue.recover()
         
         while not self.stop_event.is_set():
-            result = self.classification_queue.get_next()
-            
+            # Nothing in this loop may propagate: an uncaught exception ends the
+            # thread with the traceback going to stderr only (never the daily
+            # log), and classification silently stops for the rest of the run.
+            try:
+                result = self.classification_queue.get_next()
+            except Exception:
+                logger.error("Failed to read classification queue", exc_info=True)
+                time.sleep(1.0)
+                continue
+
             if result is None:
                 time.sleep(0.5)
                 continue
-            
+
             filepath, entry = result
-            
+
             try:
                 if entry.entry_type == "flik":
                     self._classify_flik_track(entry)
@@ -856,17 +870,21 @@ class Pipeline:
                     self._publish_dot_video(entry)
                 else:
                     self._classify_dot_track(entry)
-                
+
                 self.classification_queue.remove(filepath)
-                
+
             except Exception as e:
                 logger.error(f"Classification failed for {filepath.name}: {e}", exc_info=True)
-                should_retry = self.classification_queue.mark_failed(filepath, entry, str(e))
-                if should_retry:
+                try:
+                    should_retry = self.classification_queue.mark_failed(filepath, entry, str(e))
+                    if should_retry:
+                        time.sleep(1.0)
+                    else:
+                        # Permanently failed — still count as completed for .done check
+                        self._check_classification_complete(Path(entry.output_dir))
+                except Exception:
+                    logger.error(f"Failed to record classification failure for {filepath.name}", exc_info=True)
                     time.sleep(1.0)
-                else:
-                    # Permanently failed — still count as completed for .done check
-                    self._check_classification_complete(Path(entry.output_dir))
         
         logger.info("Classification worker stopped")
     
@@ -1120,8 +1138,15 @@ class Pipeline:
         completed_path = output_dir / ".completed_tracks"
         try:
             completed = int(completed_path.read_text().strip()) + 1
-        except (ValueError, OSError):
+        except FileNotFoundError:
             completed = 1
+        except (ValueError, OSError):
+            # An unreadable existing counter must not fall back to 1 -- that
+            # walks the count backwards and the directory can then never reach
+            # .expected_tracks. Skip the increment; the stale sweep finalizes
+            # the directory once the queue drains.
+            logger.warning(f"Unreadable {completed_path}; deferring to stale sweep", exc_info=True)
+            return
         completed_path.write_text(str(completed))
 
         if completed >= expected:
@@ -1134,6 +1159,19 @@ class Pipeline:
             detection_meta_path.unlink(missing_ok=True)
             self._notify_result_ready(output_dir)
     
+    def _maybe_sweep_stale_directories(self) -> None:
+        """Run the stale sweep on a wall-clock cadence, busy or idle.
+
+        Previously gated on a count of dequeued videos, so the sweep starved
+        whenever few videos arrived -- exactly the low-throughput conditions
+        where stuck directories accumulate.
+        """
+        now = time.monotonic()
+        if now - self._last_sweep_monotonic < self._sweep_interval_seconds:
+            return
+        self._last_sweep_monotonic = now
+        self._sweep_stale_directories()
+
     def _sweep_stale_directories(self) -> None:
         """Clean up FLIK output directories that are stuck without .done markers.
         
@@ -1172,9 +1210,10 @@ class Pipeline:
                         if age_seconds > orphan_threshold_seconds:
                             logger.warning(
                                 "orphaned result: %s has been .done for %.0fs but was never "
-                                "published (directory still on disk) -- no automatic retry exists for this",
+                                "published (directory still on disk); retrying publish",
                                 output_dir, age_seconds,
                             )
+                            self._notify_result_ready(output_dir)
                         continue
 
                     results_path = output_dir / "results.json"
@@ -1187,6 +1226,10 @@ class Pipeline:
                         if age_seconds > stale_threshold_seconds:
                             done_path.write_text("swept=stale\n")
                             logger.info(f"Swept stale directory: {output_dir.name} (no .expected_tracks, marked done)")
+                            # Nothing scans for .done markers -- publishing only
+                            # happens through this callback, so fire it or the
+                            # rescue is a dead letter.
+                            self._notify_result_ready(output_dir)
                     
                     elif results_path.exists() and expected_path.exists():
                         # Has expected tracks but not all completed
@@ -1202,9 +1245,22 @@ class Pipeline:
                             completed = 0
                         
                         age_seconds = (datetime.now().timestamp() - output_dir.stat().st_mtime)
-                        if age_seconds > stale_threshold_seconds and completed >= expected:
+                        if age_seconds > stale_threshold_seconds:
+                            if completed < expected:
+                                # No pending or in-flight entries anywhere means the
+                                # missing completions can never arrive (entry lost or
+                                # corrupted); ship what exists instead of stranding it.
+                                # With entries still queued, completions may yet come.
+                                if self.classification_queue.count() > 0:
+                                    continue
+                                logger.warning(
+                                    "Sweeping %s with %d/%d tracks classified; "
+                                    "remaining completions can no longer arrive",
+                                    output_dir.name, completed, expected,
+                                )
                             done_path.write_text(f"swept=stale\ncompleted={completed}\nexpected={expected}\n")
-                            logger.info(f"Swept stale directory: {output_dir.name} (all completed but no .done)")
+                            logger.info(f"Swept stale directory: {output_dir.name} ({completed}/{expected} completed, no .done)")
+                            self._notify_result_ready(output_dir)
                     
                     # Case 2: Empty directory (no results.json, no classification activity)
                     elif not results_path.exists() and not expected_path.exists():
@@ -1220,7 +1276,7 @@ class Pipeline:
                                 shutil.rmtree(output_dir)
                                 logger.info(f"Removed empty stale directory: {output_dir.name}")
         except Exception as e:
-            logger.warning(f"Error during stale directory sweep: {e}")
+            logger.warning(f"Error during stale directory sweep: {e}", exc_info=True)
     
     # ------------------------------------------------------------------
     # Pipeline Control

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -266,6 +266,18 @@ class Pipeline:
         video_path.unlink()
         logger.info("DOT video staged for upload: %s (dropped local copy)", video_path.name)
 
+    def _publish_finalized_result(self, entry: QueueEntry) -> None:
+        """Ship a finalized (.done) result dir to the upload owner. Runs in the
+        main-process classification worker (which holds Pollen); detection only
+        enqueues -- in subprocess mode it has no upload callback of its own.
+        Publish failures are not retried through the queue: the directory stays
+        on disk and the orphan sweep retries it, unlike DOT videos where the
+        queue entry is the only pointer to the file."""
+        output_dir = Path(entry.output_dir)
+        if not output_dir.exists():
+            return  # already published/cleaned: idempotent
+        self._notify_result_ready(output_dir)
+
     def _is_flick_video(self, path: Path) -> bool:
         """Check if a path is a FLICK video (matches flick_id prefix)."""
         return (path.is_file()
@@ -526,8 +538,6 @@ class Pipeline:
                         break
                     self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
-                
-                self._maybe_sweep_stale_directories()
 
             except queue.Empty:
                 # Drop-folder mode: no recorder feeds the video queue, so pick
@@ -546,8 +556,6 @@ class Pipeline:
                         break
                     self._process_dot_media(dot_dir)
                     self._process_dot_directory_detection(dot_dir)
-
-                self._maybe_sweep_stale_directories()
 
                 # If recording stopped, check if we're done
                 if self.recording_stopped.is_set():
@@ -754,7 +762,21 @@ class Pipeline:
                 self.writer.write_results(results=empty_results, output_dir=output_dir)
                 (output_dir / ".done").write_text("classified=0\nexpected=0\n")
                 logger.info("  No confirmed tracks, marked directory done")
-                self._notify_result_ready(output_dir)
+                # Detection runs in a subprocess with no upload callback, so
+                # hand the finalized dir to the main-process classification
+                # worker (which owns Pollen) via the disk queue, same path as
+                # tracks. Notifying from here would strand the directory --
+                # zero-track dirs have no track entries, so nothing else ever
+                # triggers a main-process publish for them.
+                self.classification_queue.enqueue(
+                    entry_type="result",
+                    source_device=self.flick_id,
+                    date=date_time[:8],
+                    time=track_timestamp,
+                    track_id=output_dir.name,
+                    track_dir=output_dir,
+                    output_dir=output_dir,
+                )
 
         except Exception as e:
             logger.error(f"Failed to process {video_path.name}: {e}", exc_info=True)
@@ -884,6 +906,15 @@ class Pipeline:
             # Nothing in this loop may propagate: an uncaught exception ends the
             # thread with the traceback going to stderr only (never the daily
             # log), and classification silently stops for the rest of the run.
+
+            # The stale sweep lives here, not in the detection worker: in
+            # subprocess mode detection has no upload callback, so its orphan
+            # publish retries could never actually publish.
+            try:
+                self._maybe_sweep_stale_directories()
+            except Exception:
+                logger.error("Stale directory sweep failed", exc_info=True)
+
             try:
                 result = self.classification_queue.get_next()
             except Exception:
@@ -902,6 +933,8 @@ class Pipeline:
                     self._classify_flik_track(entry)
                 elif entry.entry_type == "video":
                     self._publish_dot_video(entry)
+                elif entry.entry_type == "result":
+                    self._publish_finalized_result(entry)
                 else:
                     self._classify_dot_track(entry)
 
@@ -1227,13 +1260,11 @@ class Pipeline:
         2. Empty directories with no results.json and no .done — created by detection
            but never populated. Remove them if older than 10 minutes.
         """
+
         stale_threshold_seconds = 30 * 60
         empty_threshold_seconds = 10 * 60
         orphan_threshold_seconds = 180 * 60
-        # Producer-owned utility dirs, not per-timestamp result directories -- treating
-        # them the same risked shutil.rmtree racing a live writer (e.g. the heartbeat
-        # loop) that finds its own directory briefly empty and mid-write.
-        NON_RESULT_SUBDIRS = {"heartbeats", "environment", "logs"}
+
         # Per-pass tallies: one summary line per sweep makes stuck-state growth
         # visible in the daily log without scanning the disk by hand.
         scanned = 0

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -94,6 +94,10 @@ class Pipeline:
         self.enable_processing = pipeline_config.get("enable_processing", True)
         self.enable_classification = pipeline_config.get("enable_classification", True)
         self.continuous_tracking = pipeline_config.get("continuous_tracking", False)
+        # With recording disabled, treat the input dir as a drop folder: keep
+        # the detection loop alive and poll for injected FLIK videos instead of
+        # exiting once the startup scan drains.
+        self.watch_input = pipeline_config.get("watch_input", False)
 
         # Run the GIL-heavy detection loop in its own subprocess so it cannot
         # starve the recorder threads (dropped-frame fix). The child is a
@@ -305,6 +309,14 @@ class Pipeline:
         
         return items
     
+    def _find_flick_videos(self) -> list:
+        """Find unprocessed FLIK videos in input_storage (chronological)."""
+        if not self.input_storage.exists():
+            return []
+
+        return [f for f in sorted(self.input_storage.iterdir())
+                if self._is_flick_video(f)]
+
     def _find_dot_directories(self) -> list:
         """Find unprocessed DOT directories in input_storage."""
         if not self.input_storage.exists() or not self.dot_ids:
@@ -518,6 +530,16 @@ class Pipeline:
                 self._maybe_sweep_stale_directories()
 
             except queue.Empty:
+                # Drop-folder mode: no recorder feeds the video queue, so pick
+                # up injected FLIK videos ourselves. Processing deletes each
+                # video, so anything found here is unprocessed. Inject with mv
+                # (atomic) -- a file mid-copy could be picked up truncated.
+                if self.watch_input:
+                    for video in self._find_flick_videos():
+                        if self.stop_event.is_set():
+                            break
+                        self._process_video_detection(video)
+
                 # Check for new DOT directories while waiting
                 for dot_dir in self._find_dot_directories():
                     if self.stop_event.is_set():
@@ -537,6 +559,11 @@ class Pipeline:
                     pending_count = self.classification_queue.count()
                     if remaining == 0 and not has_ready_tracks and pending_count == 0:
                         logger.info("Queue empty - processing complete")
+                        # Nothing sets stop_event on the drain path otherwise,
+                        # so the classification worker would keep the process
+                        # joined forever. All queues are provably empty here
+                        # (an in-flight entry still counts in pending_count).
+                        self.stop_event.set()
                         break
                 continue
             except Exception as e:
@@ -1421,9 +1448,14 @@ class Pipeline:
             )
             self.recorder_thread.start()
             logger.info("Recorder thread started")
+        elif self.watch_input:
+            # Drop-folder mode: leave recording_stopped unset so the detection
+            # loop keeps polling for injected videos instead of draining and
+            # exiting; stop_recording() (e.g. Ctrl+C) ends the watch.
+            logger.info("Recording disabled; watching %s for injected input", self.input_storage)
         else:
             self.recording_stopped.set()  # No recording
-        
+
         # Start detection worker — an in-process thread, or a dedicated
         # subprocess (separate interpreter/GIL) when detection_in_subprocess is
         # enabled, so detection can't starve the recorder threads.

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -17,6 +17,11 @@ from bugcam.edge26.output import ResultsWriter
 from bugcam.edge26.queue import ClassificationQueue, QueueEntry
 from bugcam.log_shipping import DailyLogHandler, ship_existing_logs
 
+# Producer-owned utility dirs under a device dir, not per-timestamp result
+# directories -- the sweep and inventory must never treat them as results
+# (rmtree'ing one races its live writer, e.g. the heartbeat loop).
+NON_RESULT_SUBDIRS = {"heartbeats", "environment", "logs"}
+
 
 def setup_logging(log_dir: Path, *, on_log_complete=None) -> None:
     """Configure logging to console and a daily-rotating file.
@@ -145,6 +150,8 @@ class Pipeline:
         # --- Tracker reset signals (continuous_tracking mode) ---
         self._last_sweep_monotonic = time.monotonic()
         self._sweep_interval_seconds = 300.0
+        self._status_interval_seconds = 600.0
+        self._status_thread = None
         # 1. Day-change: reset when the date in the filename changes
         self._last_video_date: str = ""
         # 2. Recording-stop: reset after the last recorded video is processed
@@ -1127,11 +1134,21 @@ class Pipeline:
         """
         expected_path = output_dir / ".expected_tracks"
         if not expected_path.exists():
+            if (output_dir / ".done").exists():
+                # Re-check after finalization (e.g. a retried entry): benign.
+                logger.debug(f"Completion check on already-finalized {output_dir.name}")
+            else:
+                logger.warning(
+                    "completion for %s cannot be tracked: no .expected_tracks and not "
+                    "finalized -- this track's completion is lost (stale sweep must rescue)",
+                    output_dir,
+                )
             return
 
         try:
             expected = int(expected_path.read_text().strip())
         except (ValueError, OSError):
+            logger.warning(f"Unreadable {expected_path}; completion cannot be tracked", exc_info=True)
             return
 
         # Atomically increment completed count
@@ -1148,6 +1165,7 @@ class Pipeline:
             logger.warning(f"Unreadable {completed_path}; deferring to stale sweep", exc_info=True)
             return
         completed_path.write_text(str(completed))
+        logger.info(f"  Classification progress: {completed}/{expected} in {output_dir.name}")
 
         if completed >= expected:
             done_path = output_dir / ".done"
@@ -1189,6 +1207,13 @@ class Pipeline:
         # them the same risked shutil.rmtree racing a live writer (e.g. the heartbeat
         # loop) that finds its own directory briefly empty and mid-write.
         NON_RESULT_SUBDIRS = {"heartbeats", "environment", "logs"}
+        # Per-pass tallies: one summary line per sweep makes stuck-state growth
+        # visible in the daily log without scanning the disk by hand.
+        scanned = 0
+        orphans_retried = 0
+        rescued = 0
+        removed_empty = 0
+        awaiting = 0
 
         try:
             for device_dir in self.results_dir.iterdir():
@@ -1197,6 +1222,7 @@ class Pipeline:
                 for output_dir in device_dir.iterdir():
                     if not output_dir.is_dir() or output_dir.name in NON_RESULT_SUBDIRS:
                         continue
+                    scanned += 1
 
                     done_path = output_dir / ".done"
                     if done_path.exists():
@@ -1214,6 +1240,7 @@ class Pipeline:
                                 output_dir, age_seconds,
                             )
                             self._notify_result_ready(output_dir)
+                            orphans_retried += 1
                         continue
 
                     results_path = output_dir / "results.json"
@@ -1230,6 +1257,7 @@ class Pipeline:
                             # happens through this callback, so fire it or the
                             # rescue is a dead letter.
                             self._notify_result_ready(output_dir)
+                            rescued += 1
                     
                     elif results_path.exists() and expected_path.exists():
                         # Has expected tracks but not all completed
@@ -1252,6 +1280,7 @@ class Pipeline:
                                 # corrupted); ship what exists instead of stranding it.
                                 # With entries still queued, completions may yet come.
                                 if self.classification_queue.count() > 0:
+                                    awaiting += 1
                                     continue
                                 logger.warning(
                                     "Sweeping %s with %d/%d tracks classified; "
@@ -1261,6 +1290,9 @@ class Pipeline:
                             done_path.write_text(f"swept=stale\ncompleted={completed}\nexpected={expected}\n")
                             logger.info(f"Swept stale directory: {output_dir.name} ({completed}/{expected} completed, no .done)")
                             self._notify_result_ready(output_dir)
+                            rescued += 1
+                        else:
+                            awaiting += 1
                     
                     # Case 2: Empty directory (no results.json, no classification activity)
                     elif not results_path.exists() and not expected_path.exists():
@@ -1275,19 +1307,111 @@ class Pipeline:
                             if age_seconds > empty_threshold_seconds:
                                 shutil.rmtree(output_dir)
                                 logger.info(f"Removed empty stale directory: {output_dir.name}")
+                                removed_empty += 1
         except Exception as e:
             logger.warning(f"Error during stale directory sweep: {e}", exc_info=True)
+
+        summary = (
+            f"Sweep pass: {scanned} result dir(s) on disk, {awaiting} awaiting classification, "
+            f"{rescued} rescued, {orphans_retried} orphan publish retries, {removed_empty} empty removed"
+        )
+        # Quiet at debug when there is nothing on disk and nothing happened;
+        # anything else is worth a line in the daily log.
+        if scanned == 0:
+            logger.debug(summary)
+        else:
+            logger.info(summary)
     
+    def _log_results_inventory(self) -> None:
+        """One-shot startup scan of leftover result dirs from prior runs.
+
+        Every dir counted here is work a previous run did not finish shipping;
+        logging the split at boot dates when stuck state appeared without
+        needing shell access to the device.
+        """
+        try:
+            total = finalized_unpublished = awaiting = other = 0
+            if self.results_dir.is_dir():
+                for device_dir in self.results_dir.iterdir():
+                    if not device_dir.is_dir():
+                        continue
+                    for output_dir in device_dir.iterdir():
+                        if not output_dir.is_dir() or output_dir.name in NON_RESULT_SUBDIRS:
+                            continue
+                        total += 1
+                        if (output_dir / ".done").exists():
+                            finalized_unpublished += 1
+                        elif (output_dir / ".expected_tracks").exists():
+                            awaiting += 1
+                        else:
+                            other += 1
+            if total == 0:
+                logger.info("Startup inventory: no leftover result dirs")
+            else:
+                log = logger.warning if finalized_unpublished else logger.info
+                log(
+                    "Startup inventory: %d leftover result dir(s): %d finalized but never "
+                    "published (.done), %d awaiting classification (.expected_tracks), %d other",
+                    total, finalized_unpublished, awaiting, other,
+                )
+        except Exception:
+            logger.warning("Startup inventory scan failed", exc_info=True)
+
+    def _status_loop(self) -> None:
+        """Periodic liveness/backlog line in the daily log.
+
+        A worker that dies from an uncaught exception reports its traceback to
+        stderr only -- the daily log just goes quiet. This line turns that
+        silence into an explicit DEAD marker, plus queue depths for backlog
+        trend analysis after the fact.
+        """
+        while not self.stop_event.wait(self._status_interval_seconds):
+            try:
+                parts = []
+                dead_unexpectedly = []
+                recording_active = not self.recording_stopped.is_set()
+                for name, worker, required in (
+                    ("recorder", self.recorder_thread, recording_active),
+                    # Detection exits legitimately once recording has stopped
+                    # and its queues drain; classification only exits on
+                    # stop_event, so while we are looping it must be alive.
+                    ("detection", self.detection_process or self.detection_thread, recording_active),
+                    ("classification", self.classification_thread, True),
+                ):
+                    if worker is None:
+                        continue
+                    alive = worker.is_alive()
+                    parts.append(f"{name}={'alive' if alive else 'DEAD'}")
+                    if not alive and required:
+                        dead_unexpectedly.append(name)
+                try:
+                    video_backlog = self.video_queue.qsize()
+                except NotImplementedError:
+                    video_backlog = -1
+                line = (
+                    f"STATUS: {' '.join(parts)} | video_queue={video_backlog} "
+                    f"classify_queue={self.classification_queue.count()}"
+                )
+                if dead_unexpectedly:
+                    logger.error(f"{line} -- {', '.join(dead_unexpectedly)} died; "
+                                 "check stderr/journal for the traceback")
+                else:
+                    logger.info(line)
+            except Exception:
+                logger.warning("Status loop error", exc_info=True)
+
     # ------------------------------------------------------------------
     # Pipeline Control
     # ------------------------------------------------------------------
-    
+
     def start(self) -> None:
         """Start the pipeline."""
         logger.info("=" * 60)
         logger.info("STARTING PIPELINE")
         logger.info("=" * 60)
-        
+
+        self._log_results_inventory()
+
         # Start recorder (if enabled)
         if self.enable_recording and self.recorder:
             self.recorder_thread = threading.Thread(
@@ -1333,6 +1457,13 @@ class Pipeline:
                 self.classification_thread.start()
                 logger.info("Classification thread started")
         
+        self._status_thread = threading.Thread(
+            target=self._status_loop,
+            daemon=True,
+            name="PipelineStatus",
+        )
+        self._status_thread.start()
+
         if self.enable_recording and self.enable_processing:
             logger.info("Pipeline running - Ctrl+C to stop recording (processing continues)")
         elif self.enable_recording:

--- a/bugcam/edge26/main.py
+++ b/bugcam/edge26/main.py
@@ -215,24 +215,32 @@ class Pipeline:
         )
     
     def _notify_result_ready(self, output_dir: Path) -> None:
-        """Tell the upload owner (Pollen) a result dir is finalized, if wired."""
-        if self._on_result_ready is not None:
-            try:
-                self._on_result_ready(output_dir)
-            except Exception:
-                logger.error("result-ready callback failed", exc_info=True)
+        # Tell the upload owner (Pollen) a result dir is finalized, if wired.
+        if self._on_result_ready is None:
+            logger.warning(
+                "no upload owner wired; %s is finalized (.done) but will NOT be shipped or retried",
+                output_dir,
+            )
+            return
+        try:
+            self._on_result_ready(output_dir)
+        except Exception:
+            logger.error("result-ready callback failed for %s", output_dir, exc_info=True)
 
     def _notify_video_ready(self, video_path: Path, device: str) -> bool:
         """Tell the upload owner a DOT video is ready. DOT videos are not tied to a
         track, so they ship as their own unit keyed under the device/day. Returns True
         if an upload owner took it (staged it), so the producer can drop its copy."""
         if self._on_video_ready is None:
+            logger.warning(
+                "no upload owner wired; %s (device=%s) will NOT be shipped", video_path, device,
+            )
             return False
         try:
             self._on_video_ready(video_path, device)
             return True
         except Exception:
-            logger.error("video-ready callback failed", exc_info=True)
+            logger.error("video-ready callback failed for %s (device=%s)", video_path, device, exc_info=True)
             return False
 
     def _publish_dot_video(self, entry: QueueEntry) -> None:
@@ -1138,19 +1146,37 @@ class Pipeline:
         """
         stale_threshold_seconds = 30 * 60
         empty_threshold_seconds = 10 * 60
-        
+        orphan_threshold_seconds = 180 * 60
+        # Producer-owned utility dirs, not per-timestamp result directories -- treating
+        # them the same risked shutil.rmtree racing a live writer (e.g. the heartbeat
+        # loop) that finds its own directory briefly empty and mid-write.
+        NON_RESULT_SUBDIRS = {"heartbeats", "environment", "logs"}
+
         try:
             for device_dir in self.results_dir.iterdir():
                 if not device_dir.is_dir():
                     continue
                 for output_dir in device_dir.iterdir():
-                    if not output_dir.is_dir():
+                    if not output_dir.is_dir() or output_dir.name in NON_RESULT_SUBDIRS:
                         continue
-                    
+
                     done_path = output_dir / ".done"
                     if done_path.exists():
+                        # A finalized directory that is still fully present past the
+                        # threshold was never actually published (a successful
+                        # enqueue_set is always followed by shutil.rmtree of this
+                        # exact directory) -- e.g. no upload owner was wired at the
+                        # moment it finished, or the callback raised. Otherwise
+                        # invisible until someone manually finds these on disk.
+                        age_seconds = (datetime.now().timestamp() - done_path.stat().st_mtime)
+                        if age_seconds > orphan_threshold_seconds:
+                            logger.warning(
+                                "orphaned result: %s has been .done for %.0fs but was never "
+                                "published (directory still on disk) -- no automatic retry exists for this",
+                                output_dir, age_seconds,
+                            )
                         continue
-                    
+
                     results_path = output_dir / "results.json"
                     expected_path = output_dir / ".expected_tracks"
                     

--- a/bugcam/edge26/queue.py
+++ b/bugcam/edge26/queue.py
@@ -99,7 +99,10 @@ class ClassificationQueue:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
             filename = f"{source_device}_{date}_{timestamp}_{track_id}.json"
             filepath = self.pending_dir / filename
-            temp_path = self.pending_dir / f".tmp_{filename}"
+            # Temp name must not end in .json: get_next()'s *.json glob matches
+            # leading-dot names on Python >= 3.11, so a half-written temp file
+            # could be picked up (or vanish between glob and stat).
+            temp_path = self.pending_dir / f"{filename}.tmp"
             temp_path.write_text(entry.to_json())
             temp_path.rename(filepath)
             logger.debug(f"Queued for classification: {filepath.name}")
@@ -162,7 +165,12 @@ class ClassificationQueue:
 
         with self._lock:
             if filepath.exists():
-                filepath.write_text(entry.to_json())
+                # Rewrite atomically: an in-place write torn by a crash leaves a
+                # truncated entry that get_next() can only discard as corrupted,
+                # permanently losing the track's completion count.
+                temp_path = filepath.with_name(f"{filepath.name}.tmp")
+                temp_path.write_text(entry.to_json())
+                temp_path.rename(filepath)
         logger.warning(f"Entry {filepath.name} failed "
                       f"(retry {entry.retry_count}/{MAX_RETRIES}): {error}")
         return True
@@ -185,6 +193,13 @@ class ClassificationQueue:
 
     def recover(self) -> int:
         """Recover pending entries after crash. Returns count."""
+        # An orphaned temp file is an enqueue that died before the rename: that
+        # track was already counted in .expected_tracks but will never be
+        # classified, so its directory relies on the stale sweep to finalize.
+        with self._lock:
+            for temp_path in list(self.pending_dir.glob("*.tmp")) + list(self.pending_dir.glob(".tmp_*.json")):
+                logger.warning(f"Removing orphaned queue temp file (lost enqueue): {temp_path.name}")
+                temp_path.unlink(missing_ok=True)
         count = self.count()
         if count > 0:
             logger.info(f"Recovered {count} pending classification(s) from {self.pending_dir}")

--- a/bugcam/edge26/result_publish.py
+++ b/bugcam/edge26/result_publish.py
@@ -7,11 +7,10 @@ archives), then deletes its own dir. The spooler does no scanning or classificat
 """
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 from pathlib import Path
-
-from bugcam.pollen.upload_utils import result_is_empty
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +19,27 @@ SIDECARS = {
     ".done", ".detection.json", ".expected_tracks", ".completed_tracks",
     ".uploaded", ".archived", ".archived-aux",
 }
+
+
+def result_is_empty(results_json: Path) -> bool:
+    """True when a result has zero tracks and no crop/composite/video media."""
+    results_json = Path(results_json)
+    try:
+        payload = json.loads(results_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if payload.get("tracks"):
+        return False
+    results_dir = results_json.parent
+    for sub in ("crops", "composites", "videos"):
+        media_dir = results_dir / sub
+        if media_dir.is_dir() and any(p.is_file() for p in media_dir.rglob("*")):
+            return False
+    # The FLIK video sample lands top-level (video.mp4), not under videos/;
+    # a zero-track dir holding one is exactly the backdrop footage case.
+    if any(p.is_file() and p.suffix == ".mp4" for p in results_dir.iterdir()):
+        return False
+    return True
 
 
 def _owning_device(results_dir: Path, flick_id: str, dot_ids: list[str]):

--- a/bugcam/edge26/result_publish.py
+++ b/bugcam/edge26/result_publish.py
@@ -52,10 +52,15 @@ def publish_result_dir(pollen, results_dir, flick_id: str, dot_ids: list[str]) -
         logger.info("result %s empty -> dropped, nothing uploaded", results_dir.name)
         return 0
     files = [p for p in sorted(results_dir.rglob("*")) if p.is_file() and p.name not in SIDECARS]
+    video_count = sum(1 for p in files if p.suffix == ".mp4")
+    try:
+        total_mb = sum(p.stat().st_size for p in files) / 1e6
+    except OSError:
+        total_mb = -1.0
     ids = pollen.enqueue_set(files, device=device, kind="result")
     shutil.rmtree(results_dir, ignore_errors=True)  # enqueued -> staged; producer is done
     logger.info(
-        "published %s: %d files (device=%s, %s) -> enqueued; local dir removed",
-        results_dir.name, len(ids), device, "flik" if is_flik else "dot",
+        "published %s: %d files, %d video(s), %.1f MB (device=%s, %s) -> enqueued; local dir removed",
+        results_dir.name, len(ids), video_count, total_mb, device, "flik" if is_flik else "dot",
     )
     return len(ids)

--- a/bugcam/pollen/pollen.py
+++ b/bugcam/pollen/pollen.py
@@ -53,7 +53,7 @@ class PollenConfig:
     multipart_threshold: int = DEFAULT_MULTIPART_THRESHOLD
     part_size: int = DEFAULT_PART_SIZE
     batch: bool = False
-    videos_per_tick: int = 1  # max un-batched videos per tick, so a backlog can't starve archives
+    videos_per_tick: int = 10  # max un-batched videos per tick, so a backlog can't starve archives
     delete_after_upload: bool = True
     retain_uploaded: bool = False  # keep a local copy (in retained/) after upload
     retention_by_kind: dict[str, KindPolicy] = field(default_factory=dict)  # per-kind override
@@ -93,14 +93,24 @@ class Pollen:
         """Queue a logical set atomically: stage every file, then insert all rows in one
         transaction so claim/archive never splits the set. ``device`` is the batch group
         (stored explicitly, not parsed from the key). The producer owns its files and
-        should delete them after this returns. Returns the row ids enqueued."""
+        should delete them after this returns. Returns the row ids enqueued.
+
+        Note: if staging (hardlink) raises partway through the loop, this propagates to
+        the caller and NOTHING from this set is enqueued -- files already staged before
+        the failure become orphaned links, and the producer keeps its originals (since
+        it deletes them only after this call returns). Callers must not swallow the
+        exception silently; see Pipeline._notify_result_ready / _notify_video_ready."""
         specs: list[dict] = []
+        missing = 0
+        deduped = 0
         for path in files:
             path = Path(path)
             if not path.exists():
+                missing += 1
                 continue
             s3_key = self._derive_key(path)
             if self.store.has_key(s3_key):
+                deduped += 1
                 continue  # already queued/shipped -> skip before staging (no churn)
             size = path.stat().st_size
             staged = self._staging.link(path)
@@ -108,7 +118,19 @@ class Pollen:
                 "staging_path": str(staged), "kind": kind, "s3_key": s3_key,
                 "producer_name": str(path), "metadata": {"device": device}, "size": size,
             })
-        return self.store.enqueue_many(specs)
+        if missing or deduped:
+            logger.info(
+                "enqueue_set(device=%s, kind=%s): %d of %d file(s) skipped (missing=%d, already-queued=%d)",
+                device, kind, missing + deduped, len(files), missing, deduped,
+            )
+        ids = self.store.enqueue_many(specs)
+        if len(ids) < len(specs):
+            logger.warning(
+                "enqueue_set(device=%s, kind=%s): %d staged file(s) failed to insert "
+                "(s3_key collision at insert time) -- their staged copies are now orphaned",
+                device, kind, len(specs) - len(ids),
+            )
+        return ids
 
     def _derive_key(self, path: Path) -> str:
         root = self.config.output_root.resolve()
@@ -348,6 +370,15 @@ class Pollen:
             (r for r in members if r.kind in UNBATCHED_KINDS),
             key=_video_order,
         )
+        deferred = len(videos) - min(len(videos), self.config.videos_per_tick)
+        if deferred:
+            # The cap otherwise makes a growing backlog invisible: pending_count()
+            # keeps climbing but nothing in a per-tick log says why videos aren't
+            # draining -- one waits per tick regardless of how many pile up behind it.
+            logger.info(
+                "%d video(s) waiting behind the %d-per-tick cap (oldest: %s, %d attempt(s))",
+                deferred, self.config.videos_per_tick, videos[0].s3_key, videos[0].attempts,
+            )
         for row in videos[: self.config.videos_per_tick]:
             if self._drop_if_lost(row):
                 continue

--- a/bugcam/pollen/upload_utils.py
+++ b/bugcam/pollen/upload_utils.py
@@ -1,12 +1,9 @@
-"""Shared helpers producers lean on when deciding how to upload an artifact.
-
-Producers decide *what* to enqueue; these are the bits they share: the content type
-for a filename, and whether a result has anything worth shipping.
+"""Shared helper producers lean on when staging an artifact for upload: the
+content type for a filename. Pollen itself uses this (transport.py); produce-side
+decisions like whether a result dir has anything worth shipping live with the
+producer (bugcam.edge26.result_publish), not here.
 """
 from __future__ import annotations
-
-import json
-from pathlib import Path
 
 JSON = "application/json"
 
@@ -26,24 +23,3 @@ def content_type_for(filename: str) -> str:
     if lowered.endswith(".tar"):
         return "application/x-tar"
     return "application/octet-stream"
-
-
-def result_is_empty(results_json: Path) -> bool:
-    """True when a result has zero tracks and no crop/composite/video media."""
-    results_json = Path(results_json)
-    try:
-        payload = json.loads(results_json.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return False
-    if payload.get("tracks"):
-        return False
-    results_dir = results_json.parent
-    for sub in ("crops", "composites", "videos"):
-        media_dir = results_dir / sub
-        if media_dir.is_dir() and any(p.is_file() for p in media_dir.rglob("*")):
-            return False
-    # The FLIK video sample lands top-level (video.mp4), not under videos/;
-    # a zero-track dir holding one is exactly the backdrop footage case.
-    if any(p.is_file() and p.suffix == ".mp4" for p in results_dir.iterdir()):
-        return False
-    return True

--- a/bugcam/pollen/upload_utils.py
+++ b/bugcam/pollen/upload_utils.py
@@ -42,4 +42,8 @@ def result_is_empty(results_json: Path) -> bool:
         media_dir = results_dir / sub
         if media_dir.is_dir() and any(p.is_file() for p in media_dir.rglob("*")):
             return False
+    # The FLIK video sample lands top-level (video.mp4), not under videos/;
+    # a zero-track dir holding one is exactly the backdrop footage case.
+    if any(p.is_file() and p.suffix == ".mp4" for p in results_dir.iterdir()):
+        return False
     return True

--- a/bugcam/processing.py
+++ b/bugcam/processing.py
@@ -171,6 +171,7 @@ def build_edge26_config(
     enable_classification: bool = True,
     continuous_tracking: bool = False,
     detection_in_subprocess: bool = True,
+    watch_input: bool = False,
     model_metadata: dict[str, Any] | None = None,
     detection_config_path: Path | None = None,
 ) -> dict[str, Any]:
@@ -202,6 +203,7 @@ def build_edge26_config(
             "enable_classification": enable_classification,
             "continuous_tracking": continuous_tracking,
             "detection_in_subprocess": detection_in_subprocess,
+            "watch_input": watch_input,
             "recording_mode": recording_mode,
             "recording_interval_minutes": recording_interval,
         },

--- a/bugcam/runtime.py
+++ b/bugcam/runtime.py
@@ -42,6 +42,7 @@ def build_pipeline(
     enable_classification: bool = True,
     continuous_tracking: bool = False,
     detection_in_subprocess: bool = True,
+    watch_input: bool = False,
     detection_config_path: Path | None = None,
     on_result_ready=None,
     on_log_complete=None,
@@ -68,6 +69,7 @@ def build_pipeline(
         enable_classification=enable_classification,
         continuous_tracking=continuous_tracking,
         detection_in_subprocess=detection_in_subprocess,
+        watch_input=watch_input,
         model_metadata=provenance,
         detection_config_path=detection_config_path,
     )

--- a/poetry.lock
+++ b/poetry.lock
@@ -54,14 +54,14 @@ crt = ["awscrt (==0.32.2)"]
 
 [[package]]
 name = "bugspot"
-version = "0.4.2"
+version = "0.5.0"
 description = "Lightweight insect detection and tracking using motion-based detection"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "bugspot-0.4.2-py3-none-any.whl", hash = "sha256:bb4831bb3da00d1467913a73958c1c7e59d506eef2e372d6cf5404c256e2b184"},
-    {file = "bugspot-0.4.2.tar.gz", hash = "sha256:123a53b1d67f897e1db094591e1d5cd677487bf63ec5b7c3a777f0ee4023e8c9"},
+    {file = "bugspot-0.5.0-py3-none-any.whl", hash = "sha256:82934198104d12232f9fcfcc826550173eafc8e5775a126b5e8b6feecd39f992"},
+    {file = "bugspot-0.5.0.tar.gz", hash = "sha256:bcd9846212559f37afa1af8f9d38e63f936247e8693805de4809f22796eaf8ae"},
 ]
 
 [package.dependencies]
@@ -1188,4 +1188,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "1a47c6fe1f3b956d0b03ce62bac7ee3bdb2c893c41775d863ec8b198f6e1c19a"
+content-hash = "034da399070a982f1507d31590eaa471f0cd7517175fac9af20bcb37d8e8b1f1"

--- a/tests/test_result_entry_publish.py
+++ b/tests/test_result_entry_publish.py
@@ -1,0 +1,96 @@
+"""Zero-track FLIK result dirs publish via the disk queue (subprocess-safe).
+
+Detection may run in a subprocess with no upload callback, so a finalized
+zero-track dir (empty results + optional fallback sample video.mp4) must not be
+published from the detection side. Instead detection enqueues an
+entry_type="result" task and the main-process classification worker -- which
+holds Pollen -- fires the publish. Pins:
+  - the worker handler publishes the dir through on_result_ready;
+  - a dir with a fallback video.mp4 actually ships (video counts as media);
+  - the handler is idempotent when the dir is already published/cleaned.
+
+DOT video behavior (the same disk-queue hop) is covered by
+tests/test_dot_per_track.py.
+"""
+import json
+from pathlib import Path
+
+from bugcam.edge26.main import Pipeline
+from bugcam.edge26.queue import QueueEntry
+from bugcam.edge26.result_publish import publish_result_dir
+from bugcam.pollen.pollen import Pollen, PollenConfig
+
+
+class FakeUploader:
+    def upload(self, row):
+        pass
+
+
+def _pollen(tmp_path):
+    cfg = PollenConfig(
+        db_path=tmp_path / "pollen.db",
+        output_root=tmp_path / "out",
+        staging_dir=tmp_path / "staging",
+    )
+    cfg.output_root.mkdir(parents=True, exist_ok=True)
+    return Pollen(cfg, uploader=FakeUploader()), cfg.output_root
+
+
+def _zero_track_dir(out: Path, flick: str, chunk: str, with_video=True) -> Path:
+    """A finalized zero-track FLIK chunk dir: out/<flick>/<chunk_ts>/."""
+    rd = out / flick / chunk
+    rd.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "source_device": flick,
+        "date": chunk[:8],
+        "summary": {"total_detections": 0, "total_tracks": 0,
+                    "confirmed_tracks": 0, "unconfirmed_tracks": 0},
+        "tracks": [],
+    }
+    (rd / "results.json").write_text(json.dumps(rec), encoding="utf-8")
+    (rd / ".done").write_text("classified=0\nexpected=0\n", encoding="utf-8")
+    if with_video:
+        (rd / "video.mp4").write_bytes(b"vid")
+    return rd
+
+
+def _result_entry(rd: Path, flick: str) -> QueueEntry:
+    return QueueEntry(entry_type="result", source_device=flick, date=rd.name[:8],
+                      time=None, track_id=rd.name, track_dir=str(rd),
+                      output_dir=str(rd))
+
+
+def test_result_entry_fires_publish_callback(tmp_path):
+    pipe = Pipeline.__new__(Pipeline)
+    published = []
+    pipe._on_result_ready = published.append
+    rd = _zero_track_dir(tmp_path / "out", "FLIK4", "20260710_153602_038477")
+
+    pipe._publish_finalized_result(_result_entry(rd, "FLIK4"))
+
+    assert published == [rd]
+
+
+def test_result_entry_ships_fallback_video_dir(tmp_path):
+    """End-to-end for the stranded case: zero tracks + sample video.mp4."""
+    pol, out = _pollen(tmp_path)
+    pipe = Pipeline.__new__(Pipeline)
+    # The worker runs in the main process, where on_result_ready/Pollen are wired.
+    pipe._on_result_ready = lambda d: publish_result_dir(pol, d, "FLIK4", [])
+    rd = _zero_track_dir(out, "FLIK4", "20260710_153602_038477")
+
+    pipe._publish_finalized_result(_result_entry(rd, "FLIK4"))
+
+    rows = pol.store.claim_pending()
+    keys = {r.s3_key.rsplit("/", 1)[-1] for r in rows}
+    assert keys == {"results.json", "video.mp4"}
+    assert not rd.exists(), "published FLIK dir must be deleted after enqueue"
+
+
+def test_result_entry_noop_when_dir_already_published(tmp_path):
+    pipe = Pipeline.__new__(Pipeline)
+    pipe._on_result_ready = lambda d: (_ for _ in ()).throw(
+        AssertionError("must not publish a dir that is already gone"))
+    rd = tmp_path / "out" / "FLIK4" / "20260710_153602_038477"  # never created
+
+    pipe._publish_finalized_result(_result_entry(rd, "FLIK4"))

--- a/tests/test_result_publish.py
+++ b/tests/test_result_publish.py
@@ -1,0 +1,45 @@
+"""result_publish: the empty-result check and its use in publish_result_dir.
+
+result_is_empty lives here (not in pollen/upload_utils.py) because it has
+exactly one caller -- this module -- and decides a produce-side question
+(is this finalized dir worth shipping), not an upload-mechanics one.
+"""
+import json
+from pathlib import Path
+
+from bugcam.edge26.result_publish import result_is_empty
+
+
+def _write_results(results_dir: Path, tracks: list) -> Path:
+    results_dir.mkdir(parents=True, exist_ok=True)
+    path = results_dir / "results.json"
+    path.write_text(json.dumps({"tracks": tracks}), encoding="utf-8")
+    return path
+
+
+class TestResultIsEmpty:
+    def test_zero_tracks_no_media_is_empty(self, tmp_path):
+        results = _write_results(tmp_path / "flick1" / "chunk", [])
+        assert result_is_empty(results) is True
+
+    def test_with_tracks_not_empty(self, tmp_path):
+        results = _write_results(tmp_path / "flick1" / "chunk", [{"track_id": "t1"}])
+        assert result_is_empty(results) is False
+
+    def test_zero_tracks_with_media_not_empty(self, tmp_path):
+        results_dir = tmp_path / "flick1" / "chunk"
+        results = _write_results(results_dir, [])
+        (results_dir / "videos").mkdir()
+        (results_dir / "videos" / "clip.mp4").write_bytes(b"video")
+        assert result_is_empty(results) is False
+
+    def test_zero_tracks_with_top_level_video_sample_not_empty(self, tmp_path):
+        # FLIK's every-Nth backdrop sample is saved as <dir>/video.mp4, not
+        # under videos/ -- it must keep the result from being dropped.
+        results_dir = tmp_path / "flick1" / "chunk"
+        results = _write_results(results_dir, [])
+        (results_dir / "video.mp4").write_bytes(b"video")
+        assert result_is_empty(results) is False
+
+    def test_unreadable_results_not_empty(self, tmp_path):
+        assert result_is_empty(tmp_path / "missing.json") is False

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -42,5 +42,13 @@ class TestResultIsEmpty:
         (results_dir / "videos" / "clip.mp4").write_bytes(b"video")
         assert result_is_empty(results) is False
 
+    def test_zero_tracks_with_top_level_video_sample_not_empty(self, tmp_path):
+        # FLIK's every-Nth backdrop sample is saved as <dir>/video.mp4, not
+        # under videos/ -- it must keep the result from being dropped.
+        results_dir = tmp_path / "flick1" / "chunk"
+        results = _write_results(results_dir, [])
+        (results_dir / "video.mp4").write_bytes(b"video")
+        assert result_is_empty(results) is False
+
     def test_unreadable_results_not_empty(self, tmp_path):
         assert result_is_empty(tmp_path / "missing.json") is False

--- a/tests/test_upload_utils.py
+++ b/tests/test_upload_utils.py
@@ -1,12 +1,11 @@
-"""upload_utils: content type by filename, and the empty-result check.
+"""upload_utils: content type by filename.
 
 The skip *decisions* (current-day log, empty result) live in the producers now;
-this just covers the shared helpers they call.
+this just covers the one helper genuinely shared with pollen internals
+(transport.py). The empty-result check itself lives with its sole caller --
+see tests/test_result_publish.py.
 """
-import json
-from pathlib import Path
-
-from bugcam.pollen.upload_utils import content_type_for, result_is_empty
+from bugcam.pollen.upload_utils import content_type_for
 
 
 class TestContentType:
@@ -17,38 +16,3 @@ class TestContentType:
         assert content_type_for("edge26_20260101.log") == "text/plain"
         assert content_type_for("x.tar") == "application/x-tar"
         assert content_type_for("mystery.bin") == "application/octet-stream"
-
-
-def _write_results(results_dir: Path, tracks: list) -> Path:
-    results_dir.mkdir(parents=True, exist_ok=True)
-    path = results_dir / "results.json"
-    path.write_text(json.dumps({"tracks": tracks}), encoding="utf-8")
-    return path
-
-
-class TestResultIsEmpty:
-    def test_zero_tracks_no_media_is_empty(self, tmp_path):
-        results = _write_results(tmp_path / "flick1" / "chunk", [])
-        assert result_is_empty(results) is True
-
-    def test_with_tracks_not_empty(self, tmp_path):
-        results = _write_results(tmp_path / "flick1" / "chunk", [{"track_id": "t1"}])
-        assert result_is_empty(results) is False
-
-    def test_zero_tracks_with_media_not_empty(self, tmp_path):
-        results_dir = tmp_path / "flick1" / "chunk"
-        results = _write_results(results_dir, [])
-        (results_dir / "videos").mkdir()
-        (results_dir / "videos" / "clip.mp4").write_bytes(b"video")
-        assert result_is_empty(results) is False
-
-    def test_zero_tracks_with_top_level_video_sample_not_empty(self, tmp_path):
-        # FLIK's every-Nth backdrop sample is saved as <dir>/video.mp4, not
-        # under videos/ -- it must keep the result from being dropped.
-        results_dir = tmp_path / "flick1" / "chunk"
-        results = _write_results(results_dir, [])
-        (results_dir / "video.mp4").write_bytes(b"video")
-        assert result_is_empty(results) is False
-
-    def test_unreadable_results_not_empty(self, tmp_path):
-        assert result_is_empty(tmp_path / "missing.json") is False


### PR DESCRIPTION
Several improvements separated by commit, while investigating issues with sparse/no video uploads

### Functional 

- Batch uploads now have a default interval of 1h
- Add --record/--no-record flags to enable better testing
- Run staleness sweep based on real time


### Instrumentation

- Increased logging generally, log liveliness of essential threads/processes.

### Bugfixes

- Handled a case where sweep_stale_directories was catching the heartbeat directory while heartbeats were being written there, throwing exceptions.
- Don't enqueue before writing appropriate sidecars, this is to avoid a race condition with classification, where expected_tracks were not written before classification looked for them, causing the whole dir to be orphaned
- Don't ignore empty video samples from FLIK as we want them after a certain number of recordings where no confirmed tracks are present, this was introduced in the batching implementation.
- Pass zero-track results to classification queue to pass along to Pollen. (The inter-process-communication approach with Pollen generally needs a rethink, will be addressed in a follow-up MR).
- Poetry lock to fix pipeline after bugspot version bump