### PR TITLE
feat: wire video_sample_interval config for FLIK sample-video uploads

### DIFF
--- a/bugcam/commands/run.py
+++ b/bugcam/commands/run.py
@@ -39,6 +39,7 @@ from bugcam.receiver.tracker import PendingTrackTracker
 app = typer.Typer(help="Record, process, upload, and emit heartbeats", invoke_without_command=True, no_args_is_help=False)
 console = Console()
 HEARTBEAT_INTERVAL_SECONDS = 300
+DEFAULT_VIDEO_SAMPLE_INTERVAL = 10
 ENVIRONMENT_INTERVAL_SECONDS = 60
 PID_FILE_PATH = get_state_dir() / "bugcam.pid"
 logger = logging.getLogger(__name__)
@@ -343,6 +344,18 @@ def _resolve_capture_report_interval() -> float:
     return float(load_config().get("capture_report_interval", DEFAULT_REPORT_INTERVAL_SECONDS))
 
 
+def _resolve_video_sample_interval(video_sample_interval: int | None) -> int:
+    """Resolve the FLIK sample-video cadence: CLI flag wins, then config, then
+    default (config: video_sample_interval, default 10). Saves 1 processed
+    video per N to the upload queue; 0 disables sample-video saving entirely."""
+    resolved = video_sample_interval if video_sample_interval is not None else int(
+        load_config().get("video_sample_interval", DEFAULT_VIDEO_SAMPLE_INTERVAL)
+    )
+    if resolved < 0:
+        raise typer.BadParameter("video_sample_interval must be >= 0")
+    return resolved
+
+
 @app.callback()
 def run(
     api_url: str | None = typer.Option(None, "--api-url", help="Backend API URL"),
@@ -361,6 +374,7 @@ def run(
     bucket: str | None = typer.Option(None, "--bucket", help="Configured output bucket"),
     upload_poll: int = typer.Option(3600, "--upload-poll", help="Seconds between upload polls; with --archive-batch this is also the batch cadence (one tar per device per poll) (config: upload_poll_interval)"),
     heartbeat_interval: float | None = typer.Option(None, "--heartbeat-interval", help="Seconds between heartbeat snapshots (config: heartbeat_interval, default 300)"),
+    video_sample_interval: int | None = typer.Option(None, "--video-sample-interval", help="Save 1 processed video per N to the upload queue; 0 disables sample-video saving (config: video_sample_interval, default 10)"),
     with_receiver: bool = typer.Option(
         True,
         "--with-receiver/--no-receiver",
@@ -420,6 +434,7 @@ def run(
         window = RecordingWindow.from_config(resolved_window, resolved_timezone)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
+    resolved_video_sample_interval = _resolve_video_sample_interval(video_sample_interval)
     try:
         pid_path = _acquire_pid_file()
     except RuntimeError as exc:
@@ -536,6 +551,7 @@ def run(
             detection_config_path=detection_config,
             timezone_name=resolved_timezone,
             record_window=resolved_window,
+            video_sample_interval=resolved_video_sample_interval,
             on_result_ready=on_result_ready,
             on_log_complete=on_log_complete,
             on_video_ready=on_video_ready,

--- a/bugcam/processing.py
+++ b/bugcam/processing.py
@@ -176,6 +176,7 @@ def build_edge26_config(
     detection_config_path: Path | None = None,
     timezone_name: str | None = None,
     record_window: str | None = None,
+    video_sample_interval: int = 10,
 ) -> dict[str, Any]:
     """Build the edge26 pipeline config from BugCam-owned settings."""
     results_dir = Path(output_dir)
@@ -210,6 +211,7 @@ def build_edge26_config(
             "recording_mode": recording_mode,
             "recording_interval_minutes": recording_interval,
             "record_window": record_window,
+            "video_sample_interval": video_sample_interval,
         },
         "capture": {
             "camera_index": 0,

--- a/bugcam/runtime.py
+++ b/bugcam/runtime.py
@@ -46,6 +46,7 @@ def build_pipeline(
     detection_config_path: Path | None = None,
     timezone_name: str | None = None,
     record_window: str | None = None,
+    video_sample_interval: int = 10,
     on_result_ready=None,
     on_log_complete=None,
     on_video_ready=None,
@@ -77,6 +78,7 @@ def build_pipeline(
         detection_config_path=detection_config_path,
         timezone_name=timezone_name,
         record_window=record_window,
+        video_sample_interval=video_sample_interval,
     )
     setup_logging(Path(config["paths"]["logs_dir"]), on_log_complete=on_log_complete)
     return Pipeline(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ markers = [
 target-version = "py311"
 extend-exclude = ["time-lapse"]  # standalone experiment, not part of the bugcam package
 
+[tool.ruff.lint]
+# Pre-0.16 default rules, pinned explicitly: ruff 0.16.0 grew the default set
+# from 59 to 413 rules, and CI installs the latest ruff (ruff-action@v3 unpinned).
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["F841"]   # `with patch(...) as m` handles are kept for the patch side-effect
 "scripts/**" = ["E402"]  # helper scripts adjust sys.path before importing

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the main bugcam CLI structure."""
 import pytest
+import typer
 from bugcam.cli import app
 from tests.helpers import strip_ansi
 
@@ -78,6 +79,63 @@ def test_heartbeat_loop_waits_configured_interval(monkeypatch) -> None:
 
     run._heartbeat_loop("FLIK4", None, None, [], _StopAfterOne(), None, 5)
     assert waited == [5]
+
+
+def test_run_video_sample_interval_default_is_ten() -> None:
+    """Test the FLIK sample-video default is 1 saved per 10 processed videos."""
+    from bugcam.commands.run import DEFAULT_VIDEO_SAMPLE_INTERVAL
+
+    assert DEFAULT_VIDEO_SAMPLE_INTERVAL == 10
+
+
+def test_resolve_video_sample_interval_cli_wins(monkeypatch) -> None:
+    """An explicit --video-sample-interval overrides config and default."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {"video_sample_interval": 99})
+    assert run._resolve_video_sample_interval(5) == 5
+
+
+def test_resolve_video_sample_interval_from_config(monkeypatch) -> None:
+    """With no CLI flag, the config key is used."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {"video_sample_interval": 15})
+    assert run._resolve_video_sample_interval(None) == 15
+
+
+def test_resolve_video_sample_interval_default(monkeypatch) -> None:
+    """With neither CLI flag nor config, falls back to 10."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {})
+    assert run._resolve_video_sample_interval(None) == 10
+
+
+def test_resolve_video_sample_interval_zero_disables_sampling(monkeypatch) -> None:
+    """0 is a valid value (disables sample-video saving), not rejected."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {})
+    assert run._resolve_video_sample_interval(0) == 0
+
+
+def test_resolve_video_sample_interval_rejects_negative_cli(monkeypatch) -> None:
+    """A negative --video-sample-interval is invalid and rejected at resolve time."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {})
+    with pytest.raises(typer.BadParameter):
+        run._resolve_video_sample_interval(-1)
+
+
+def test_resolve_video_sample_interval_rejects_negative_config(monkeypatch) -> None:
+    """A negative config-file value is invalid and rejected at resolve time."""
+    from bugcam.commands import run
+
+    monkeypatch.setattr(run, "load_config", lambda: {"video_sample_interval": -3})
+    with pytest.raises(typer.BadParameter):
+        run._resolve_video_sample_interval(None)
 
 
 def test_process_subcommand_help(cli_runner):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -31,6 +31,33 @@ def test_build_edge26_config_uses_bugspot_ratio_detection_defaults(tmp_path: Pat
         assert config["detection"][key] == value
 
 
+def test_build_edge26_config_video_sample_interval_default(tmp_path: Path) -> None:
+    config = build_edge26_config(
+        flick_id="flick01",
+        dot_ids=[],
+        input_dir=str(tmp_path / "input"),
+        output_dir=str(tmp_path / "outputs"),
+        model_path=str(tmp_path / "bundle" / "model.hef"),
+        labels_path=str(tmp_path / "bundle" / "labels.txt"),
+    )
+
+    assert config["pipeline"]["video_sample_interval"] == 10
+
+
+def test_build_edge26_config_video_sample_interval_custom(tmp_path: Path) -> None:
+    config = build_edge26_config(
+        flick_id="flick01",
+        dot_ids=[],
+        input_dir=str(tmp_path / "input"),
+        output_dir=str(tmp_path / "outputs"),
+        model_path=str(tmp_path / "bundle" / "model.hef"),
+        labels_path=str(tmp_path / "bundle" / "labels.txt"),
+        video_sample_interval=25,
+    )
+
+    assert config["pipeline"]["video_sample_interval"] == 25
+
+
 def test_video_processor_passes_ratio_config_to_bugspot() -> None:
     from bugcam.edge26.processing.processor import VideoProcessor
 


### PR DESCRIPTION
The FLIK pipeline saves 1 sample video per N processed videos for upload (kind="result", via publish_result_dir), but the interval was hardcoded to 10 in edge26/main.py with no CLI flag or config-file entry to change it. Adds --video-sample-interval / config key video_sample_interval, resolved CLI > config > default (10), following the existing heartbeat_interval pattern in bugcam/commands/run.py. 0 disables sample-video saving.
