### PR TITLE
Fix/pollen reconcile

### DIFF
--- a/bugcam/pollen/pollen.py
+++ b/bugcam/pollen/pollen.py
@@ -41,6 +41,19 @@ MAX_RETRY_DELAY_SECONDS = 300  # matches the legacy upload loop
 STUCK_WARN_SECONDS = 3600      # warn loudly once the oldest item has waited this long
 
 
+def _exists_safe(path: Path) -> Optional[bool]:
+    """Like Path.exists(), but doesn't let an ambiguous OSError pass through.
+    Path.exists() already swallows ENOENT/ENOTDIR/ELOOP and returns False; it
+    re-raises anything else (e.g. ESTALE on a disconnected mount, EACCES on a
+    dead automount stub). Callers checking a path recorded on a mount that may
+    no longer exist need to tell "confirmed gone" (False) apart from "couldn't
+    tell" (None) rather than crash on the latter."""
+    try:
+        return path.exists()
+    except OSError:
+        return None
+
+
 @dataclass(frozen=True)
 class KindPolicy:
     """Per-kind retention. ``keep_after_upload`` retains a local copy (in retained/) plus
@@ -226,13 +239,26 @@ class Pollen:
     def reconcile(self) -> None:
         """Crash-recovery GC. Drop pending rows whose staged copy vanished (a lost
         upload), prune shipped rows whose file is gone, and unlink staged files no
-        row references (orphaned by a crash between link and enqueue)."""
+        row references (orphaned by a crash between link and enqueue).
+
+        A row's staging_path is whatever mount was current when it was enqueued;
+        redirecting to a new drive leaves old rows pointing at a mount that may no
+        longer be there at all. ``_exists_safe`` tells a confirmed-gone path (drop
+        it) apart from an unreachable one (stale/disconnected mount raising
+        something Path.exists() doesn't swallow) -- the latter is left alone rather
+        than guessed at."""
         for row in self.store.claim_pending():
-            if not Path(row.staging_path).exists():
+            exists = _exists_safe(Path(row.staging_path))
+            if exists is False:
                 logger.error(
                     "pollen: staged file gone for pending %s; dropping (lost upload)", row.s3_key
                 )
                 self.store.delete(row.id)
+            elif exists is None:
+                logger.warning(
+                    "pollen: could not check staged file for pending %s (mount unavailable?); "
+                    "leaving pending", row.s3_key
+                )
         self.store.prune_missing()
         known = self.store.all_staging_paths()
         now = time.time()
@@ -247,7 +273,15 @@ class Pollen:
                 self._staging.unlink(link)
 
     def _loop(self) -> None:
-        self.reconcile()  # recover orphans/lost uploads left by a previous run
+        try:
+            self.reconcile()  # recover orphans/lost uploads left by a previous run
+        except Exception:
+            # An uncaught exception here would kill this thread before the tick
+            # loop's own try/except ever runs -- and since it's a thread exception,
+            # not a logging call, it goes to stderr via threading.excepthook and
+            # never reaches the log file. Log it through the normal pipeline and
+            # keep going: a failed startup reconcile is recoverable, a dead loop is not.
+            logger.exception("pollen: startup reconcile failed; continuing without it")
         consecutive_failures = 0
         while not self._stop.is_set():
             try:

--- a/bugcam/pollen/store.py
+++ b/bugcam/pollen/store.py
@@ -66,6 +66,18 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _exists_safe(path: Path) -> Optional[bool]:
+    """Like Path.exists(), but doesn't let an ambiguous OSError pass through.
+    Path.exists() already swallows ENOENT/ENOTDIR/ELOOP and returns False; it
+    re-raises anything else (e.g. ESTALE on a disconnected mount, EACCES on a
+    dead automount stub). A path recorded on a mount that's since gone away
+    needs "confirmed gone" (False) told apart from "couldn't tell" (None)."""
+    try:
+        return path.exists()
+    except OSError:
+        return None
+
+
 class PollenStore:
     def __init__(self, db_path: str | Path) -> None:
         self.db_path = Path(db_path)
@@ -212,8 +224,13 @@ class PollenStore:
                 (UploadStatus.UPLOADED.value, UploadStatus.DONE.value),
             ).fetchall()
             # A tombstone tracks its retained producer file; fall back to the
-            # staging path for rows that never had one (e.g. archives).
-            gone = [r["id"] for r in rows if not Path(r["producer_name"] or r["staging_path"]).exists()]
+            # staging path for rows that never had one (e.g. archives). A path
+            # we can't even check (stale/disconnected mount) is left alone --
+            # see _exists_safe -- rather than treated as gone.
+            gone = [
+                r["id"] for r in rows
+                if _exists_safe(Path(r["producer_name"] or r["staging_path"])) is False
+            ]
             for row_id in gone:
                 self._conn.execute("DELETE FROM uploads WHERE id = ?", (row_id,))
             if gone:

--- a/tests/test_pollen.py
+++ b/tests/test_pollen.py
@@ -129,6 +129,23 @@ class TestLifecycle:
             pol.stop()
         assert up.uploaded == ["v1/flick1/c/results.json"]
 
+    def test_startup_reconcile_failure_does_not_kill_the_loop(self, tmp_path):
+        """A crashing startup reconcile() must not take the whole upload thread
+        down with it -- ticks (and thus uploads) must still happen afterwards."""
+        cfg = _config(tmp_path)
+        up = FakeUploader()
+        pol = _pollen(cfg, up)
+        pol.reconcile = lambda: (_ for _ in ()).throw(RuntimeError("mount unavailable"))
+        pol.start()
+        try:
+            pol.enqueue_set([_write(cfg.output_root, "flick1/c/results.json", b'{"tracks":[{"track_id":"t"}]}')], device="flick1", kind="result")
+            deadline = time.time() + 3.0
+            while not up.uploaded and time.time() < deadline:
+                time.sleep(0.01)
+        finally:
+            pol.stop()
+        assert up.uploaded == ["v1/flick1/c/results.json"]
+
 
 class TestEnqueueSource:
     def test_source_fires_on_tick(self, tmp_path):
@@ -358,6 +375,27 @@ class TestReconcile:
         Path(pol.store.get(rid).staging_path).unlink()  # staged copy vanishes
         pol.reconcile()
         assert pol.store.get(rid) is None
+
+    def test_pending_row_with_unreachable_staging_left_alone(self, tmp_path, monkeypatch):
+        """A row from a redirected/removed drive whose old mount raises something
+        other than ENOENT (a stale/disconnected mount) must not be treated as a
+        confirmed-lost upload -- and reconcile() itself must not blow up."""
+        cfg = _config(tmp_path)
+        pol = _pollen(cfg)
+        path = _write(cfg.output_root, "flick1/c/results.json", b'{"tracks":[{"track_id":"t"}]}')
+        rid = pol.enqueue_set([path], device="flick1", kind="result")[0]
+        staged = Path(pol.store.get(rid).staging_path)
+
+        real_exists = Path.exists
+
+        def flaky_exists(self):
+            if self == staged:
+                raise OSError("stale NFS file handle")
+            return real_exists(self)
+
+        monkeypatch.setattr(Path, "exists", flaky_exists)
+        pol.reconcile()  # must not raise
+        assert pol.store.get(rid) is not None  # left pending, not guessed at
 
 
 def test_read_timeout_scales_with_payload():


### PR DESCRIPTION
Pollen was failing silently due to a removal of the old bugcam folder, while state was still maintained in the pollen sqlite db. This happened early enough in pollen's startup reconciliation phase, before the block in which errors are handled and logged. This MR corrects that. 