### PR TITLE
config/setup: expand ~ in path values from env vars and config

### DIFF
--- a/bugcam/commands/setup.py
+++ b/bugcam/commands/setup.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from ..config import (
     DEFAULT_API_URL,
     DEFAULT_S3_BUCKET,
+    _expand,
     get_default_flick_id,
     get_hailo_venv_dir,
     get_python_for_detection,
@@ -409,7 +410,7 @@ def _create_storage_dirs(config: dict[str, Any]) -> None:
     ]
     for dir_path in dirs_to_create:
         if dir_path:
-            Path(dir_path).mkdir(parents=True, exist_ok=True)
+            _expand(dir_path).mkdir(parents=True, exist_ok=True)
     console.print("[green]Storage directories created.[/green]\n")
 
 

--- a/bugcam/config.py
+++ b/bugcam/config.py
@@ -74,8 +74,13 @@ def get_cache_dir() -> Path:
     """Get the cache directory for bugcam, respecting XDG_CACHE_HOME."""
     xdg_cache = os.environ.get("XDG_CACHE_HOME")
     if xdg_cache:
-        return Path(xdg_cache) / "bugcam"
+        return _expand(xdg_cache) / "bugcam"
     return Path.home() / ".cache" / "bugcam"
+
+
+def _expand(value: str) -> Path:
+    """Expand a leading '~' in a path from an env var or config value."""
+    return Path(value).expanduser()
 
 
 def _validate_state_dir(path: Path) -> None:
@@ -90,19 +95,19 @@ def get_state_dir() -> Path:
     """Get the state directory for bugcam, respecting config and environment."""
     state_dir = os.environ.get("BUGCAM_STATE_DIR")
     if state_dir:
-        path = Path(state_dir)
+        path = _expand(state_dir)
         _validate_state_dir(path)
         return path
 
     config = load_config()
     if config.get("state_dir"):
-        path = Path(str(config["state_dir"]))
+        path = _expand(str(config["state_dir"]))
         _validate_state_dir(path)
         return path
 
     xdg_data = os.environ.get("XDG_DATA_HOME")
     if xdg_data:
-        return Path(xdg_data) / "bugcam"
+        return _expand(xdg_data) / "bugcam"
     return Path.home() / ".local" / "share" / "bugcam"
 
 
@@ -110,11 +115,11 @@ def get_input_storage_dir() -> Path:
     """Get the edge26 input storage directory."""
     input_dir = os.environ.get("BUGCAM_INPUT_DIR")
     if input_dir:
-        return Path(input_dir)
+        return _expand(input_dir)
 
     config = load_config()
     if config.get("input_dir"):
-        return Path(str(config["input_dir"]))
+        return _expand(str(config["input_dir"]))
 
     return get_state_dir() / "incoming"
 
@@ -123,11 +128,11 @@ def get_pending_dir() -> Path:
     """Get the pending classification queue directory."""
     pending_dir = os.environ.get("BUGCAM_PENDING_DIR")
     if pending_dir:
-        return Path(pending_dir)
+        return _expand(pending_dir)
 
     config = load_config()
     if config.get("pending_dir"):
-        return Path(str(config["pending_dir"]))
+        return _expand(str(config["pending_dir"]))
 
     return get_state_dir() / "pending"
 
@@ -136,11 +141,11 @@ def get_output_storage_dir() -> Path:
     """Get the edge26 output storage directory."""
     output_dir = os.environ.get("BUGCAM_OUTPUT_DIR")
     if output_dir:
-        return Path(output_dir)
+        return _expand(output_dir)
 
     config = load_config()
     if config.get("output_dir"):
-        return Path(str(config["output_dir"]))
+        return _expand(str(config["output_dir"]))
 
     return get_state_dir() / "outputs"
 
@@ -174,7 +179,7 @@ def get_edge26_labels_path(model_path: Path | None = None) -> Path:
 
     labels_path = os.environ.get("BUGCAM_EDGE26_LABELS")
     if labels_path:
-        return Path(labels_path)
+        return _expand(labels_path)
 
     model_ref = os.environ.get("BUGCAM_EDGE26_MODEL")
     resolved = resolve_labels_path(model_ref)
@@ -194,7 +199,7 @@ def get_edge26_taxonomy_cache_path() -> Path:
     """Get the taxonomy cache file path."""
     cache_path = os.environ.get("BUGCAM_EDGE26_TAXONOMY_CACHE")
     if cache_path:
-        return Path(cache_path)
+        return _expand(cache_path)
     return get_state_dir() / "taxonomy-cache.json"
 
 

--- a/tests/test_config_path_expansion.py
+++ b/tests/test_config_path_expansion.py
@@ -1,0 +1,63 @@
+"""config.py path getters must expand a leading '~' from env vars and config.json values."""
+import pytest
+
+from bugcam import config
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    for var in (
+        "XDG_DATA_HOME", "XDG_CACHE_HOME", "BUGCAM_STATE_DIR", "BUGCAM_INPUT_DIR",
+        "BUGCAM_OUTPUT_DIR", "BUGCAM_PENDING_DIR", "BUGCAM_EDGE26_LABELS",
+        "BUGCAM_EDGE26_TAXONOMY_CACHE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(config, "load_config", lambda: {})
+    return tmp_path
+
+
+def test_state_dir_env_var_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("BUGCAM_STATE_DIR", "~/data/bugcam")
+    assert config.get_state_dir() == _home / "data" / "bugcam"
+
+
+def test_state_dir_config_value_tilde_expands(monkeypatch, _home):
+    monkeypatch.setattr(config, "load_config", lambda: {"state_dir": "~/data/bugcam"})
+    assert config.get_state_dir() == _home / "data" / "bugcam"
+
+
+def test_xdg_data_home_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("XDG_DATA_HOME", "~/xdg-data")
+    assert config.get_state_dir() == _home / "xdg-data" / "bugcam"
+
+
+def test_xdg_cache_home_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("XDG_CACHE_HOME", "~/xdg-cache")
+    assert config.get_cache_dir() == _home / "xdg-cache" / "bugcam"
+
+
+def test_input_storage_dir_env_var_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("BUGCAM_INPUT_DIR", "~/incoming")
+    assert config.get_input_storage_dir() == _home / "incoming"
+
+
+def test_pending_dir_config_value_tilde_expands(monkeypatch, _home):
+    monkeypatch.setattr(config, "load_config", lambda: {"pending_dir": "~/pending"})
+    assert config.get_pending_dir() == _home / "pending"
+
+
+def test_output_storage_dir_env_var_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("BUGCAM_OUTPUT_DIR", "~/outputs")
+    assert config.get_output_storage_dir() == _home / "outputs"
+
+
+def test_edge26_taxonomy_cache_env_var_tilde_expands(monkeypatch, _home):
+    monkeypatch.setenv("BUGCAM_EDGE26_TAXONOMY_CACHE", "~/taxonomy.json")
+    assert config.get_edge26_taxonomy_cache_path() == _home / "taxonomy.json"
+
+
+def test_absolute_paths_pass_through_unchanged(monkeypatch, _home, tmp_path):
+    abs_dir = tmp_path / "elsewhere"
+    monkeypatch.setenv("BUGCAM_STATE_DIR", str(abs_dir))
+    assert config.get_state_dir() == abs_dir

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -7,6 +7,16 @@ from typer.testing import CliRunner
 from bugcam.cli import app
 
 
+def test_create_storage_dirs_expands_tilde(tmp_path: Path, monkeypatch) -> None:
+    """A literal '~' from the setup prompt must resolve to $HOME."""
+    from bugcam.commands.setup import _create_storage_dirs
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _create_storage_dirs({"state_dir": "~/data/bugcam"})
+    assert (tmp_path / "data" / "bugcam").is_dir()
+    assert not (tmp_path / "~").exists()
+
+
 def test_setup_help(cli_runner: CliRunner) -> None:
     """Test setup command help."""
     result = cli_runner.invoke(app, ["setup", "--help"])


### PR DESCRIPTION
This changes behaviour so testing and config changes is necessary. Means that '\~' in config is expanded to /home/<user> where appropriate. 