### PR TITLE
Add device configs pulled from SGSCA6,7,9,10,11,13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ build/
 .coverage
 htmlcov/
 crops/
+
+# API keys pulled alongside device_configs/ live outside the repo now
+# (~/Development/titus/device_config_secrets/); this is a backstop in case
+# one ever lands here again.
+device_configs/**/*.secret.json

--- a/device_configs/SGSCA10/config.json
+++ b/device_configs/SGSCA10/config.json
@@ -1,0 +1,22 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK4-dot01",
+    "FLIK4-dot02",
+    "FLIK4-dot03",
+    "FLIK4-dot04",
+    "FLIK4-dot05"
+  ],
+  "flick_id": "FLIK4",
+  "heartbeat_interval": 300,
+  "input_dir": "/home/pi/fresh/incoming",
+  "output_dir": "/home/pi/fresh/outputs",
+  "pending_dir": "/home/pi/fresh/pending",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "~/.local/share/bugcam",
+  "upload_poll_interval": 3600,
+  "timezone": "Europe/Amsterdam",
+  "record_window": "05:00-22:00",
+  "video_sample_interval": 4
+}

--- a/device_configs/SGSCA10/detection.yaml
+++ b/device_configs/SGSCA10/detection.yaml
@@ -1,0 +1,155 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIGURATION
+# =============================================================================
+# This config controls motion-based insect detection parameters.
+# All values shown are defaults - modify as needed for your use case.
+#
+# RESOLUTION-INDEPENDENT UNITS
+# ----------------------------
+# Scene-scale pixel parameters below are given as FRACTIONS of the input
+# image dimensions, not as absolute pixels. This makes a single config
+# work across any resolution. Two reference dimensions are used:
+#
+#   * Length-based -> fraction of image width W
+#         Keys:  min_displacement, max_frame_jump, revisit_radius
+#   * Area-based   -> fraction of image area (W * H)
+#         Keys:  min_area, max_area
+#
+# Examples below show the resolved pixel value for a 1080 px wide square
+# frame (1080 x 1080, area = 1,166,400 px^2):
+#   min_area: 0.0002        ->   ~233 px^2
+#   min_displacement: 0.05  ->    54  px
+#
+# `morph_kernel_size` is an exception: it is a local noise-removal
+# kernel and stays in absolute pixels (NxN) regardless of resolution.
+#
+# Usage:
+#   results = inference(..., config="detection_config.yaml")
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# GMM BACKGROUND SUBTRACTOR PARAMETERS
+# -----------------------------------------------------------------------------
+# Controls the Gaussian Mixture Model for motion detection
+
+# Number of frames to build background model
+# Higher = more stable background, slower adaptation to lighting changes
+gmm_history: 500
+
+# Variance threshold for foreground detection
+# Higher = less sensitive, fewer false positives from noise
+gmm_var_threshold: 16
+
+# -----------------------------------------------------------------------------
+# MORPHOLOGICAL FILTERING
+# -----------------------------------------------------------------------------
+# Noise removal after motion detection
+
+# Size of the morphological kernel in pixels (NxN ellipse).
+# This is an absolute pixel count, NOT a fraction of image width — the
+# kernel targets sensor-level noise, not scene-scale features.
+# Larger = removes more noise but may lose small detections.
+morph_kernel_size: 3
+
+# -----------------------------------------------------------------------------
+# COHESIVENESS PARAMETERS
+# -----------------------------------------------------------------------------
+# These filter scattered motion (wind-blown plants) vs compact motion (insects)
+
+# Min ratio of largest blob to total motion area in detection region
+# Higher = stricter, rejects fragmented detections
+min_largest_blob_ratio: 0.70
+
+# Max number of separate blobs allowed in a detection region
+# Lower = stricter, rejects scattered motion
+max_num_blobs: 5
+
+# Min ratio of motion pixels to bounding box area
+# Higher = requires more filled bounding box
+min_motion_ratio: 0.15
+
+# -----------------------------------------------------------------------------
+# SHAPE PARAMETERS
+# -----------------------------------------------------------------------------
+# Filter detections by contour geometry
+
+# Min contour area as FRACTION of image area (rejects noise/tiny detections)
+# 0.0002 on a 1080 x 1080 frame ~= 233 px^2
+min_area: 0.0002
+
+# Max contour area as FRACTION of image area (rejects large moving objects)
+# 0.035 on a 1080 x 1080 frame ~= 40,824 px^2
+max_area: 0.095
+
+# Min area/perimeter ratio (rejects thin/elongated shapes)
+# Unitless shape descriptor; not scaled with image size.
+min_density: 3.0
+
+# Min convex hull fill ratio (rejects irregular/fragmented shapes)
+# 1.0 = perfectly convex, lower = more irregular allowed
+min_solidity: 0.55
+
+# -----------------------------------------------------------------------------
+# TRACKING PARAMETERS
+# -----------------------------------------------------------------------------
+# Control how detections are linked into tracks
+
+# Min NET displacement for track confirmation, as FRACTION of image width.
+# Filters stationary false positives.
+# 0.05 on a 1080 px wide frame = 54 px
+min_displacement: 0.05
+
+# Min path points required before topology analysis
+min_path_points: 10
+
+# Max allowed jump between consecutive frames, as FRACTION of image width.
+# Larger = more tolerant of fast movement, but may link separate objects.
+# 0.1 on a 1080 px wide frame = 108 px
+max_frame_jump: 0.2
+
+# How many frames to remember a lost track before deleting
+# Helps re-link tracks after brief occlusions (e.g., 45 frames @ 30fps = 1.5s)
+max_lost_frames: 45
+
+# Max allowed area change ratio between frames
+# Prevents linking very different sized detections
+max_area_change_ratio: 3.0
+
+# -----------------------------------------------------------------------------
+# TRACKER MATCHING PARAMETERS
+# -----------------------------------------------------------------------------
+# Hungarian algorithm cost function weights
+
+# Weight for distance cost (0-1)
+# Higher = position matters more for matching
+tracker_w_dist: 0.6
+
+# Weight for area cost (0-1)
+# Higher = size similarity matters more for matching
+tracker_w_area: 0.4
+
+# Maximum cost for valid track-detection match (0-1)
+# Lower = stricter matching, more new tracks created
+tracker_cost_threshold: 0.3
+
+# -----------------------------------------------------------------------------
+# PATH TOPOLOGY PARAMETERS
+# -----------------------------------------------------------------------------
+# Confirm insect-like movement patterns vs random/stationary motion
+
+# Max ratio of revisited positions (insects explore new areas)
+# Lower = stricter, requires more exploration
+max_revisit_ratio: 0.30
+
+# Min forward progression ratio (insects move purposefully)
+# Higher = stricter, requires more directional movement
+min_progression_ratio: 0.70
+
+# Max directional variance (insects maintain relatively consistent heading)
+# Lower = stricter, requires more consistent direction
+max_directional_variance: 0.90
+
+# Radius for determining if a position is "revisited", as FRACTION of image width.
+# Smaller = stricter definition of revisiting.
+# 0.05 on a 1080 px wide frame = 54 px
+revisit_radius: 0.05

--- a/device_configs/SGSCA11/config.json
+++ b/device_configs/SGSCA11/config.json
@@ -1,0 +1,22 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK3-dot01",
+    "FLIK3-dot02",
+    "FLIK3-dot03",
+    "FLIK3-dot04",
+    "FLIK3-dot05"
+  ],
+  "flick_id": "FLIK3",
+  "heartbeat_interval": 300,
+  "input_dir": "/home/pi/bugcam/incoming",
+  "output_dir": "/home/pi/bugcam/outputs",
+  "pending_dir": "/home/pi/bugcam/pending",
+  "record_window": "05:00-22:00",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "~/.local/share/bugcam",
+  "timezone": "Europe/Amsterdam",
+  "upload_poll_interval": 3600,
+  "video_sample_interval": 10
+}

--- a/device_configs/SGSCA11/detection.yaml
+++ b/device_configs/SGSCA11/detection.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIG  —  4K LANDSCAPE @ 30 fps
+# =============================================================================
+# Default detection parameters for bugcam. Override with --detection-config
+# or create ~/.config/bugcam/detection.yaml for local customization.
+# =============================================================================
+
+# GMM background subtractor
+gmm_history:        500
+gmm_var_threshold:  16
+
+# Morphological filtering (absolute pixels)
+morph_kernel_size:  5
+
+# Detection resolution (speed): explicit [width, height] (px) to run the
+# detector at. Detection runs on resized frames while bounding boxes are scaled
+# back to native res, so crops/composites stay full resolution. null = native.
+# For 4K capture, e.g. [960, 540] detects at 960x540 (~16x fewer pixels).
+detection_resolution:  [1920, 1080]
+
+# Reference resolution: the resolution morph_kernel_size/min_density were tuned
+# for. This config is tuned for 4K, so those two params auto-scale from 4K to
+# whatever resolution detection runs at (native or detection_resolution) — e.g.
+# running on a native 1080p video scales them down automatically, no re-tuning.
+reference_resolution:  [3840, 2160]
+
+# Cohesiveness — filters scattered motion (wind on plants)
+min_largest_blob_ratio: 0.85
+max_num_blobs:          3
+min_motion_ratio:       0.20
+
+# Per-detection size + shape filters
+min_area:           0.00012
+max_area:           0.0015
+min_density:        3.0
+min_solidity:       0.55
+
+# Tracking
+min_displacement:       0.25
+min_path_points:        10
+max_frame_jump:         0.06
+max_lost_frames:        45
+max_area_change_ratio:  3.0
+
+# Tracker matching (Hungarian cost weights)
+tracker_w_dist:         0.6
+tracker_w_area:         0.4
+tracker_cost_threshold: 0.25
+
+# Path topology — insect-like vs plant-like motion
+revisit_radius:           0.025
+max_revisit_ratio:        0.30
+min_progression_ratio:    0.70
+max_directional_variance: 0.85

--- a/device_configs/SGSCA13/config.json
+++ b/device_configs/SGSCA13/config.json
@@ -1,0 +1,22 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK13-dot01",
+    "FLIK13-dot02",
+    "FLIK13-dot03",
+    "FLIK13-dot04",
+    "FLIK13-dot05"
+  ],
+  "flick_id": "FLIK13",
+  "heartbeat_interval": 300,
+  "input_dir": "/media/pi/New_data/bugcam/incoming",
+  "output_dir": "/media/pi/New_data/bugcam/outputs",
+  "pending_dir": "/media/pi/New_data/bugcam/pending",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "~/.local/share/bugcam",
+  "upload_poll_interval": 3600,
+  "timezone": "Europe/London",
+  "record_window": "05:00-22:00",
+  "video_sample_interval": 4
+}

--- a/device_configs/SGSCA13/detection.yaml
+++ b/device_configs/SGSCA13/detection.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIG  —  4K LANDSCAPE @ 30 fps
+# =============================================================================
+# Default detection parameters for bugcam. Override with --detection-config
+# or create ~/.config/bugcam/detection.yaml for local customization.
+# =============================================================================
+
+# GMM background subtractor
+gmm_history:        500
+gmm_var_threshold:  16
+
+# Morphological filtering (absolute pixels)
+morph_kernel_size:  5
+
+# Detection resolution (speed): explicit [width, height] (px) to run the
+# detector at. Detection runs on resized frames while bounding boxes are scaled
+# back to native res, so crops/composites stay full resolution. null = native.
+# For 4K capture, e.g. [960, 540] detects at 960x540 (~16x fewer pixels).
+detection_resolution:  [1920, 1080]
+
+# Reference resolution: the resolution morph_kernel_size/min_density were tuned
+# for. This config is tuned for 4K, so those two params auto-scale from 4K to
+# whatever resolution detection runs at (native or detection_resolution) — e.g.
+# running on a native 1080p video scales them down automatically, no re-tuning.
+reference_resolution:  [3840, 2160]
+
+# Cohesiveness — filters scattered motion (wind on plants)
+min_largest_blob_ratio: 0.85
+max_num_blobs:          3
+min_motion_ratio:       0.20
+
+# Per-detection size + shape filters
+min_area:           0.00012
+max_area:           0.0015
+min_density:        3.0
+min_solidity:       0.55
+
+# Tracking
+min_displacement:       0.25
+min_path_points:        10
+max_frame_jump:         0.06
+max_lost_frames:        45
+max_area_change_ratio:  3.0
+
+# Tracker matching (Hungarian cost weights)
+tracker_w_dist:         0.6
+tracker_w_area:         0.4
+tracker_cost_threshold: 0.25
+
+# Path topology — insect-like vs plant-like motion
+revisit_radius:           0.025
+max_revisit_ratio:        0.30
+min_progression_ratio:    0.70
+max_directional_variance: 0.85

--- a/device_configs/SGSCA6/config.json
+++ b/device_configs/SGSCA6/config.json
@@ -1,0 +1,22 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK6-dot01",
+    "FLIK6-dot02",
+    "FLIK6-dot03",
+    "FLIK6-dot04",
+    "FLIK6-dot05"
+  ],
+  "flick_id": "FLIK6",
+  "heartbeat_interval": 300,
+  "input_dir": "/home/pi/bugcam/incoming",
+  "output_dir": "/home/pi/bugcam/outputs",
+  "pending_dir": "/home/pi/bugcam/pending",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "/home/pi/.local/share/bugcam",
+  "upload_poll_interval": 3600,
+  "timezone": "Europe/London",
+  "record_window": "06:00-23:00",
+  "video_sample_interval": 4
+}

--- a/device_configs/SGSCA6/detection.yaml
+++ b/device_configs/SGSCA6/detection.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIG  —  4K LANDSCAPE @ 30 fps
+# =============================================================================
+# Default detection parameters for bugcam. Override with --detection-config
+# or create ~/.config/bugcam/detection.yaml for local customization.
+# =============================================================================
+
+# GMM background subtractor
+gmm_history:        500
+gmm_var_threshold:  16
+
+# Morphological filtering (absolute pixels)
+morph_kernel_size:  5
+
+# Detection resolution (speed): explicit [width, height] (px) to run the
+# detector at. Detection runs on resized frames while bounding boxes are scaled
+# back to native res, so crops/composites stay full resolution. null = native.
+# For 4K capture, e.g. [960, 540] detects at 960x540 (~16x fewer pixels).
+detection_resolution:  [1920, 1080]
+
+# Reference resolution: the resolution morph_kernel_size/min_density were tuned
+# for. This config is tuned for 4K, so those two params auto-scale from 4K to
+# whatever resolution detection runs at (native or detection_resolution) — e.g.
+# running on a native 1080p video scales them down automatically, no re-tuning.
+reference_resolution:  [3840, 2160]
+
+# Cohesiveness — filters scattered motion (wind on plants)
+min_largest_blob_ratio: 0.85
+max_num_blobs:          3
+min_motion_ratio:       0.20
+
+# Per-detection size + shape filters
+min_area:           0.00012
+max_area:           0.0015
+min_density:        3.0
+min_solidity:       0.55
+
+# Tracking
+min_displacement:       0.25
+min_path_points:        10
+max_frame_jump:         0.06
+max_lost_frames:        45
+max_area_change_ratio:  3.0
+
+# Tracker matching (Hungarian cost weights)
+tracker_w_dist:         0.6
+tracker_w_area:         0.4
+tracker_cost_threshold: 0.25
+
+# Path topology — insect-like vs plant-like motion
+revisit_radius:           0.025
+max_revisit_ratio:        0.30
+min_progression_ratio:    0.70
+max_directional_variance: 0.85

--- a/device_configs/SGSCA7/config.json
+++ b/device_configs/SGSCA7/config.json
@@ -1,0 +1,22 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK7-dot01",
+    "FLIK7-dot02",
+    "FLIK7-dot03",
+    "FLIK7-dot04",
+    "FLIK7-dot05"
+  ],
+  "flick_id": "FLIK7",
+  "heartbeat_interval": 300,
+  "upload_poll_interval": 3600,
+  "input_dir": "/home/pi/bugcam/incoming",
+  "output_dir": "/home/pi/bugcam/outputs",
+  "pending_dir": "/home/pi/bugcam/pending",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "~/.local/share/bugcam",
+  "timezone": "America/Toronto",
+  "video_sample_interval": 10,
+  "record_window": "05:00-22:00"
+}

--- a/device_configs/SGSCA7/detection.yaml
+++ b/device_configs/SGSCA7/detection.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIG  —  4K LANDSCAPE @ 30 fps
+# =============================================================================
+# Default detection parameters for bugcam. Override with --detection-config
+# or create ~/.config/bugcam/detection.yaml for local customization.
+# =============================================================================
+
+# GMM background subtractor
+gmm_history:        500
+gmm_var_threshold:  16
+
+# Morphological filtering (absolute pixels)
+morph_kernel_size:  5
+
+# Detection resolution (speed): explicit [width, height] (px) to run the
+# detector at. Detection runs on resized frames while bounding boxes are scaled
+# back to native res, so crops/composites stay full resolution. null = native.
+# For 4K capture, e.g. [960, 540] detects at 960x540 (~16x fewer pixels).
+detection_resolution:  [1920, 1080]
+
+# Reference resolution: the resolution morph_kernel_size/min_density were tuned
+# for. This config is tuned for 4K, so those two params auto-scale from 4K to
+# whatever resolution detection runs at (native or detection_resolution) — e.g.
+# running on a native 1080p video scales them down automatically, no re-tuning.
+reference_resolution:  [3840, 2160]
+
+# Cohesiveness — filters scattered motion (wind on plants)
+min_largest_blob_ratio: 0.85
+max_num_blobs:          3
+min_motion_ratio:       0.20
+
+# Per-detection size + shape filters
+min_area:           0.00012
+max_area:           0.0015
+min_density:        3.0
+min_solidity:       0.55
+
+# Tracking
+min_displacement:       0.25
+min_path_points:        10
+max_frame_jump:         0.06
+max_lost_frames:        45
+max_area_change_ratio:  3.0
+
+# Tracker matching (Hungarian cost weights)
+tracker_w_dist:         0.6
+tracker_w_area:         0.4
+tracker_cost_threshold: 0.25
+
+# Path topology — insect-like vs plant-like motion
+revisit_radius:           0.025
+max_revisit_ratio:        0.30
+min_progression_ratio:    0.70
+max_directional_variance: 0.85

--- a/device_configs/SGSCA9/config.json
+++ b/device_configs/SGSCA9/config.json
@@ -1,0 +1,21 @@
+{
+  "api_url": "https://api.sensinggarden.com/v1",
+  "archive_batch": true,
+  "dot_ids": [
+    "FLIK9-dot01",
+    "FLIK9-dot02",
+    "FLIK9-dot03",
+    "FLIK9-dot04",
+    "FLIK9-dot05"
+  ],
+  "flick_id": "FLIK9",
+  "heartbeat_interval": 300,
+  "input_dir": "/home/pi/bugcam/incoming",
+  "output_dir": "/home/pi/bugcam/outputs",
+  "pending_dir": "/home/pi/bugcam/pending",
+  "s3_bucket": "scl-sensing-garden",
+  "state_dir": "~/.local/share/bugcam",
+  "upload_poll_interval": 3600,
+  "timezone": "America/Toronto",
+  "record_window": "05:00-22:00"
+}

--- a/device_configs/SGSCA9/detection.yaml
+++ b/device_configs/SGSCA9/detection.yaml
@@ -1,0 +1,54 @@
+# =============================================================================
+# BUGSPOT DETECTION CONFIG  —  4K LANDSCAPE @ 30 fps
+# =============================================================================
+# Default detection parameters for bugcam. Override with --detection-config
+# or create ~/.config/bugcam/detection.yaml for local customization.
+# =============================================================================
+
+# GMM background subtractor
+gmm_history:        500
+gmm_var_threshold:  16
+
+# Morphological filtering (absolute pixels)
+morph_kernel_size:  5
+
+# Detection resolution (speed): explicit [width, height] (px) to run the
+# detector at. Detection runs on resized frames while bounding boxes are scaled
+# back to native res, so crops/composites stay full resolution. null = native.
+# For 4K capture, e.g. [960, 540] detects at 960x540 (~16x fewer pixels).
+detection_resolution:  [1920, 1080]
+
+# Reference resolution: the resolution morph_kernel_size/min_density were tuned
+# for. This config is tuned for 4K, so those two params auto-scale from 4K to
+# whatever resolution detection runs at (native or detection_resolution) — e.g.
+# running on a native 1080p video scales them down automatically, no re-tuning.
+reference_resolution:  [3840, 2160]
+
+# Cohesiveness — filters scattered motion (wind on plants)
+min_largest_blob_ratio: 0.85
+max_num_blobs:          3
+min_motion_ratio:       0.20
+
+# Per-detection size + shape filters
+min_area:           0.00012
+max_area:           0.0015
+min_density:        3.0
+min_solidity:       0.55
+
+# Tracking
+min_displacement:       0.25
+min_path_points:        10
+max_frame_jump:         0.06
+max_lost_frames:        45
+max_area_change_ratio:  3.0
+
+# Tracker matching (Hungarian cost weights)
+tracker_w_dist:         0.6
+tracker_w_area:         0.4
+tracker_cost_threshold: 0.25
+
+# Path topology — insect-like vs plant-like motion
+revisit_radius:           0.025
+max_revisit_ratio:        0.30
+min_progression_ratio:    0.70
+max_directional_variance: 0.85


### PR DESCRIPTION
detection.yaml and config.json (with api_key stripped) from each live Pi's ~/sensing-garden/bugcam/detection.yaml and ~/.config/bugcam/config.json. API keys live outside the repo at ~/Development/titus/device_config_secrets/. SGSCA8 is currently unreachable (dead) and was skipped.